### PR TITLE
GetClientRect

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -100,8 +100,7 @@ namespace Hearthstone_Deck_Tracker
         public double Card2PosX = 0.25;
         public double CardPosY = 0.3;
         public double SearchBoxX = 0.5;
-        public double SearchBoxY = 0.89;
-        public double SearchBoxYFullscreen = 0.92;
+        public double SearchBoxY = 0.92;
         public double NameDeckX = 0.8;
         public double NameDeckY = 0.05;
         public bool ExportSetDeckName = true;

--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -70,10 +70,9 @@ namespace Hearthstone_Deck_Tracker
         {
             var ratio = (double) width/height;
 
-            var searchBoxY = (isFullscreen ? _config.SearchBoxYFullscreen : _config.SearchBoxY);
             var cardPosX = ratio < 1.5 ? width*_config.CardPosX : width*_config.CardPosX*(ratio/1.33);
 
-            var searchBoxPos = new Point((int) (_config.SearchBoxX*width), (int) (searchBoxY*height));
+            var searchBoxPos = new Point((int) (_config.SearchBoxX*width), (int) (_config.SearchBoxY*height));
             var cardPos = new Point((int) cardPosX, (int) (_config.CardPosY*height));
 
             await ClickOnPoint(hsHandle, searchBoxPos);
@@ -105,7 +104,7 @@ namespace Hearthstone_Deck_Tracker
                 }
                 else
                 {
-                    await ClickOnPoint(hsHandle, cardPos);
+                    await ClickOnPoint(hsHandle, new Point((int)cardPosX, (int)cardPosY));
                 }
                 
             }
@@ -137,7 +136,7 @@ namespace Hearthstone_Deck_Tracker
             else
                 User32.mouse_event((uint)User32.MouseEventFlags.LeftDown, 0, 0, 0, UIntPtr.Zero);
 
-            await Task.Delay(_config.ClickDelay);
+            //await Task.Delay(_config.ClickDelay);
 
             //mouse up
             if (SystemInformation.MouseButtonsSwapped)

--- a/Hearthstone Deck Tracker/User32.cs
+++ b/Hearthstone Deck Tracker/User32.cs
@@ -11,9 +11,6 @@ namespace Hearthstone_Deck_Tracker
         public const int SwRestore = 9;
 
         [DllImport("user32.dll")]
-        public static extern IntPtr GetWindowRect(IntPtr hWnd, ref Rect rect);
-        
-        [DllImport("user32.dll")]
         public static extern IntPtr GetClientRect(IntPtr hWnd, ref Rect rect);
 
         [DllImport("user32.dll", CharSet = CharSet.Unicode)]
@@ -59,7 +56,7 @@ namespace Hearthstone_Deck_Tracker
             public int right;
             public int bottom;
         }
-
+        
         [Flags]
         public enum MouseEventFlags : uint
         {
@@ -79,25 +76,42 @@ namespace Hearthstone_Deck_Tracker
             public int X;
             public int Y;
         }
+        
         public static Point GetMousePos()
         {
             var p = new MousePoint();
             GetCursorPos(out p);
             return new Point(p.X, p.Y);
         }
+        
         public static Rectangle GetHearthstoneRect(bool dpiScaling)
         {
-            var rect = new Rect();
-            GetClientRect(FindWindow("UnityWndClass", "Hearthstone"), ref rect);
+        	// Returns the co-ordinates of Hearthstone's client area in screen co-ordinates
+            var hsHandle = FindWindow("UnityWndClass", "Hearthstone");
+        	var rect = new Rect();
+            var ptUL = new Point();
+            var ptLR = new Point();
+            
+            GetClientRect(hsHandle, ref rect);
+            
+            ptUL.X = rect.left;
+            ptUL.Y = rect.top;
+ 
+            ptLR.X = rect.right;
+            ptLR.Y = rect.bottom;
+            
+            ClientToScreen(hsHandle, ref ptUL);
+            ClientToScreen(hsHandle, ref ptLR);
+ 
             if (dpiScaling)
             {
-                rect.top = (int) (rect.top/Helper.DpiScalingY);
-                rect.bottom = (int) (rect.bottom/Helper.DpiScalingY);
-                rect.left = (int) (rect.left/Helper.DpiScalingX);
-                rect.right = (int) (rect.right/Helper.DpiScalingX);
+                ptUL.X = (int) (ptUL.X / Helper.DpiScalingX);
+            	ptUL.Y = (int) (ptUL.Y / Helper.DpiScalingY);
+                ptLR.X = (int) (ptLR.X / Helper.DpiScalingX);
+            	ptLR.Y = (int) (ptLR.Y / Helper.DpiScalingY);
             }
-            return new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
+            
+            return new Rectangle(ptUL.X, ptUL.Y, ptLR.X - ptUL.X, ptLR.Y - ptUL.Y);
         }
-
     }
 }

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -177,8 +177,8 @@ namespace Hearthstone_Deck_Tracker
             Left = left + _offsetX;
             Width = (_customWidth == -1) ? width : _customWidth;
             Height = (_customHeight == -1) ? height : _customHeight;
-            CanvasInfo.Height = (_customHeight == -1) ? height : _customHeight;
-            CanvasInfo.Width = (_customWidth == -1) ? width : _customWidth;
+            //CanvasInfo.Width = (_customWidth == -1) ? width : _customWidth;
+            //CanvasInfo.Height = (_customHeight == -1) ? height : _customHeight;
         }
 
         private void ReSizePosLists()
@@ -238,11 +238,12 @@ namespace Hearthstone_Deck_Tracker
                            Width*_config.TimersHorizontalPosition/100 + _config.TimersHorizontalSpacing);
 
 
-            Canvas.SetTop(LblGrid,
-                          (Helper.IsFullscreen("Hearthstone")
-                               ? Height*0.03
-                               : Height*0.03 + SystemParameters.CaptionHeight));
-
+//            Canvas.SetTop(LblGrid,
+//                          (Helper.IsFullscreen("Hearthstone")
+//                               ? Height*0.03
+//                               : Height*0.03 + SystemParameters.CaptionHeight));
+            
+            Canvas.SetTop(LblGrid, Height*0.03);
 
             var ratio = Width/Height;
             LblGrid.Width = ratio < 1.5 ? Width*0.3 : Width*0.15*(ratio/1.33);


### PR DESCRIPTION
GetClientRect returns the co-ordinates of a window's client area - ie. the area of a window minus the title bar and the window's borders.

GetWindowRect returns co-ordinates indicating the area of the whole window, title bar and border included.

This will provide for:-
a more accurate/simpler auto-clicker in DeckExporter
accurate positioning of overlays
eliminates the need for both fullscreen and windowed variables in config.xml for the co-ordinates of controls in Hearthstone.
