### PR TITLE
Prevents crash when scaling is set to 0

### DIFF
--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -494,6 +494,8 @@ namespace Hearthstone_Deck_Tracker
 
         public void UpdateScaling()
         {
+            _config.OverlayPlayerScaling += 0.00001;
+            _config.OverlayOpponentScaling += 0.00001;
             StackPanelPlayer.RenderTransform = new ScaleTransform(_config.OverlayPlayerScaling/100,
                                                                   _config.OverlayPlayerScaling/100);
             StackPanelOpponent.RenderTransform = new ScaleTransform(_config.OverlayOpponentScaling/100,


### PR DESCRIPTION
Keeps the scaling above 0 at all times to prevent crashes when trying to display stuff.
