### PR TITLE
Change the secrets' tooltips from being 'accessable' after StackPanelSecret...

### DIFF
--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -616,7 +616,7 @@ namespace Hearthstone_Deck_Tracker
 
         public void HideSecrets()
         {
-            StackPanelSecrets.Visibility = Visibility.Hidden;
+            StackPanelSecrets.Visibility = Visibility.Collapsed;
         }
     }
 }


### PR DESCRIPTION
...s has been changed to hidden.

After all secrets have been triggered and/or game has ended the tooltips are being shown on mouse-over in the area where the secrets panel use to be visible.

Change HideSecrets() to set the secrets panel to 'collapsed' instead of 'hidden'.
Set to 'collapsed' removes the panel from the overlay - UpdateCardTooltip() doesn't show the tooltips on mouse hover-over where the stackpanel existed.
