### PR TITLE
Fix deck exporting to HS

### DIFF
--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -76,8 +76,7 @@ namespace Hearthstone_Deck_Tracker
             var cardPos = new Point((int) cardPosX, (int) (_config.CardPosY*height));
 
             await ClickOnPoint(hsHandle, searchBoxPos);
-            SendKeys.SendWait("^(a)");
-            SendKeys.SendWait(FixCardName(card.LocalizedName));
+            SendKeys.SendWait(FixCardName(card.LocalizedName).ToLower());
             SendKeys.SendWait("{ENTER}");
 
             await Task.Delay(_config.SearchDelay);


### PR DESCRIPTION
A possible fix for users encountering errors exporting decks to HS using language/kb layout other than English/US.

Sending 'Ctrl A' to select all text in search box may have been causing the issues with another character being prepended to card names.

Also, change the card name being sent to lowercase.

Ref: Issue #83 
