### PR TITLE
Fixed text case issue which causing problem in some languages

### DIFF
--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -76,7 +76,7 @@ namespace Hearthstone_Deck_Tracker
             var cardPos = new Point((int) cardPosX, (int) (_config.CardPosY*height));
 
             await ClickOnPoint(hsHandle, searchBoxPos);
-            SendKeys.SendWait(FixCardName(card.LocalizedName).ToLower());
+            SendKeys.SendWait(FixCardName(card.LocalizedName).ToLowerInvariant());
             SendKeys.SendWait("{ENTER}");
 
             await Task.Delay(_config.SearchDelay);

--- a/Hearthstone Deck Tracker/Hearthstone/Card.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Card.cs
@@ -232,7 +232,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
                 }
                 try
                 {
-                    string cardFileName = Name.ToLower().Replace(' ', '-').Replace(":", "").Replace("'", "-").Replace(".", "").Replace("!", "") + ".png";
+                    string cardFileName = Name.ToLowerInvariant().Replace(' ', '-').Replace(":", "").Replace("'", "-").Replace(".", "").Replace("!", "") + ".png";
 
                     
                    //card graphic

--- a/Hearthstone Deck Tracker/Hearthstone/Game.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Game.cs
@@ -197,7 +197,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
         {
             if (GetActualCards().Any(c => c.Name.Equals(name)))
             {
-                return (Card) GetActualCards().FirstOrDefault(c => c.Name.ToLower() == name.ToLower()).Clone();
+                return (Card) GetActualCards().FirstOrDefault(c => c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase)).Clone();
             }
 
             //not sure with all the values here

--- a/Hearthstone Deck Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/MainWindow.xaml.cs
@@ -1962,7 +1962,7 @@ namespace Hearthstone_Deck_Tracker
 
                 foreach (var card in _game.GetActualCards())
                 {
-                    if (!card.LocalizedName.ToLower().Contains(TextBoxDBFilter.Text.ToLower()))
+                    if (!card.LocalizedName.ToLowerInvariant().Contains(TextBoxDBFilter.Text.ToLowerInvariant()))
                         continue;
                     // mana filter
                     if (ComboBoxFilterMana.SelectedItem.ToString() == "All"


### PR DESCRIPTION
![](http://i.imgur.com/qpMf6pc.png)

When using `ToLower()` in Turkish `I` becomes `ı` and therefore app unable to find filename because expected char was `i`. To solve this problem need to use invariant culture when doing text comparison or case changes.

![](http://i.imgur.com/dhiWKTl.png)

Also UI have this problem too but i can't find where this case change happens, probably because it is inside `MahApps.Metro.dll`?
