### PR TITLE
Fix FlashHs checkbox not being properly set at startup

### DIFF
--- a/Hearthstone Deck Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/MainWindow.xaml.cs
@@ -305,7 +305,7 @@ namespace Hearthstone_Deck_Tracker
 			CheckboxExportName.IsChecked = Config.Instance.ExportSetDeckName;
 			CheckboxPrioGolden.IsChecked = Config.Instance.PrioritizeGolden;
 			CheckboxBringHsToForegorund.IsChecked = Config.Instance.BringHsToForeground;
-			CheckboxFlashHs.IsChecked = Config.Instance.BringHsToForeground;
+			CheckboxFlashHs.IsChecked = Config.Instance.FlashHs;
 			CheckboxHideSecrets.IsChecked = Config.Instance.HideSecrets;
 			CheckboxHighlightDiscarded.IsChecked = Config.Instance.HighlightDiscarded;
 			CheckboxRemoveCards.IsChecked = Config.Instance.RemoveCardsFromDeck;


### PR DESCRIPTION
State of FlashHs checkbox was being set by BringHsToForeground in the config file.
