### PR TITLE
Hide deck sorting on edit tag flyouts

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/SortFilterDecks.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/SortFilterDecks.xaml
@@ -9,7 +9,7 @@
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>
         <StackPanel Margin="6,0,6,0">
-            <DockPanel>
+            <DockPanel x:Name="PnlSortDecks">
                 <Label Content="Sort decks by:" FontSize="14"/>
                 <ComboBox Name="ComboboxDeckSorting" Width="120" HorizontalAlignment="Right" SelectionChanged="Selector_OnSelectionChanged">
                     <system:String>Name</system:String>

--- a/Hearthstone Deck Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/MainWindow.xaml.cs
@@ -2128,6 +2128,8 @@ namespace Hearthstone_Deck_Tracker
 			SortFilterDecksFlyout.HideStuffToCreateNewTag();
 			TagControlNewDeck.OperationSwitch.Visibility = Visibility.Collapsed;
 			TagControlMyDecks.OperationSwitch.Visibility = Visibility.Collapsed;
+			TagControlNewDeck.PnlSortDecks.Visibility = Visibility.Collapsed;
+			TagControlMyDecks.PnlSortDecks.Visibility = Visibility.Collapsed;
 
 			SortFilterDecksFlyout.SelectedTagsChanged += SortFilterDecksFlyoutOnSelectedTagsChanged;
 			SortFilterDecksFlyout.OperationChanged += SortFilterDecksFlyoutOnOperationChanged;


### PR DESCRIPTION
Like the operation switch, we don't need to see the deck sorting controls on the edit tag flyouts.
