### PR TITLE
Change when Mana Curve (New Deck) gets Updated

### DIFF
--- a/Hearthstone Deck Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/MainWindow.xaml.cs
@@ -846,8 +846,6 @@ namespace Hearthstone_Deck_Tracker
 						}
 					}
 				}
-				if (NewDeck != null)
-					ManaCurveNewDeck.SetDeck(NewDeck);
 
 				Helper.SortCardCollection(ListViewDB.Items, Config.Instance.CardSortingClassFirst);
 			}
@@ -963,7 +961,8 @@ namespace Hearthstone_Deck_Tracker
 			}
 			else
 				NewDeck.Cards.Remove(card);
-
+			
+			ManaCurveNewDeck.SetDeck(NewDeck);
 			Helper.SortCardCollection(ListViewNewDeck.Items, Config.Instance.CardSortingClassFirst);
 			BtnSaveDeck.Content = "Save*";
 			UpdateNewDeckHeader(true);
@@ -992,6 +991,7 @@ namespace Hearthstone_Deck_Tracker
 				NewDeck.Cards.Add(card);
 			}
 
+			ManaCurveNewDeck.SetDeck(NewDeck);
 			Helper.SortCardCollection(ListViewNewDeck.Items, Config.Instance.CardSortingClassFirst);
 			BtnSaveDeck.Content = "Save*";
 			UpdateNewDeckHeader(true);


### PR DESCRIPTION
Previously, the Mana Curve was being updated every time dbListView were being updated.
Thus, on every keypress in the card search the Mana Curve was also being updated resulting in slower card search performance.

Changed the Mana Curve to being updated only when a card has been added/removed from the deck.
