### PR TITLE
Fix #135 - Don't save or use -32000 win positions

### DIFF
--- a/Hearthstone Deck Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/MainWindow.xaml.cs
@@ -182,8 +182,12 @@ namespace Hearthstone_Deck_Tracker
 		private void MetroWindow_LocationChanged(object sender, EventArgs e)
 		{
 			if (WindowState == WindowState.Minimized) return;
-			Config.Instance.TrackerWindowTop = (int)Top;
-			Config.Instance.TrackerWindowLeft = (int)Left;
+
+			if (Top != -32000)
+				Config.Instance.TrackerWindowTop = (int)Top;
+
+			if (Left != -32000)
+				Config.Instance.TrackerWindowLeft = (int)Left;
 		}
 
 		private void TabControlTracker_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -258,9 +262,9 @@ namespace Hearthstone_Deck_Tracker
 			}
 			else
 			{
-				if (Config.Instance.TrackerWindowTop.HasValue)
+				if (Config.Instance.TrackerWindowTop.HasValue && Config.Instance.TrackerWindowTop != -32000)
 					Top = Config.Instance.TrackerWindowTop.Value;
-				if (Config.Instance.TrackerWindowLeft.HasValue)
+				if (Config.Instance.TrackerWindowLeft.HasValue && Config.Instance.TrackerWindowLeft != -32000)
 					Left = Config.Instance.TrackerWindowLeft.Value;
 			}
 

--- a/Hearthstone Deck Tracker/Windows/OpponentWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OpponentWindow.xaml.cs
@@ -23,11 +23,11 @@ namespace Hearthstone_Deck_Tracker
 			ListViewOpponent.ItemsSource = opponentDeck;
 			opponentDeck.CollectionChanged += OpponentDeckOnCollectionChanged;
 			Height = _config.OpponentWindowHeight;
-			if (_config.OpponentWindowLeft.HasValue)
+			if (_config.OpponentWindowLeft.HasValue && _config.OpponentWindowLeft != -32000)
 			{
 				Left = _config.OpponentWindowLeft.Value;
 			}
-			if (_config.OpponentWindowTop.HasValue)
+			if (_config.OpponentWindowTop.HasValue && _config.OpponentWindowTop != -32000)
 			{
 				Top = _config.OpponentWindowTop.Value;
 			}
@@ -124,8 +124,12 @@ namespace Hearthstone_Deck_Tracker
 		private void MetroWindow_LocationChanged(object sender, EventArgs e)
 		{
 			if (WindowState == WindowState.Minimized) return;
-			_config.OpponentWindowLeft = (int) Left;
-			_config.OpponentWindowTop = (int) Top;
+
+			if (Left != -32000)
+				_config.OpponentWindowLeft = (int) Left;
+
+			if (Top != -32000)
+				_config.OpponentWindowTop = (int) Top;
 		}
 
 		public void SetTextLocation(bool top)

--- a/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml.cs
@@ -25,11 +25,11 @@ namespace Hearthstone_Deck_Tracker
 			ListViewPlayer.ItemsSource = playerDeck;
 			playerDeck.CollectionChanged += PlayerDeckOnCollectionChanged;
 			Height = _config.PlayerWindowHeight;
-			if (_config.PlayerWindowLeft.HasValue)
+			if (_config.PlayerWindowLeft.HasValue && _config.PlayerWindowLeft != -32000)
 			{
 				Left = _config.PlayerWindowLeft.Value;
 			}
-			if (_config.PlayerWindowTop.HasValue)
+			if (_config.PlayerWindowTop.HasValue && _config.PlayerWindowTop != -32000)
 			{
 				Top = _config.PlayerWindowTop.Value;
 			}
@@ -127,8 +127,12 @@ namespace Hearthstone_Deck_Tracker
 		{
 			if (_forScreenshot) return;
 			if (WindowState == WindowState.Minimized) return;
-			_config.PlayerWindowLeft = (int) Left;
-			_config.PlayerWindowTop = (int) Top;
+
+			if (Left != -32000)
+				_config.PlayerWindowLeft = (int) Left;
+
+			if (Top != -32000)
+				_config.PlayerWindowTop = (int) Top;
 		}
 
 		public void SetTextLocation(bool top)

--- a/Hearthstone Deck Tracker/Windows/TimerWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/TimerWindow.xaml.cs
@@ -20,11 +20,11 @@ namespace Hearthstone_Deck_Tracker
 			Height = _config.TimerWindowHeight;
 			Width = _config.TimerWindowWidth;
 
-			if (_config.TimerWindowLeft.HasValue)
+			if (_config.TimerWindowLeft.HasValue && _config.TimerWindowLeft != -32000)
 			{
 				Left = config.TimerWindowLeft.Value;
 			}
-			if (_config.TimerWindowTop.HasValue)
+			if (_config.TimerWindowTop.HasValue && _config.TimerWindowTop != -32000)
 			{
 				Top = config.TimerWindowTop.Value;
 			}
@@ -56,8 +56,11 @@ namespace Hearthstone_Deck_Tracker
 
 		private void MetroWindow_LocationChanged(object sender, EventArgs e)
 		{
-			_config.TimerWindowLeft = (int) Left;
-			_config.TimerWindowTop = (int) Top;
+			if (Left != -32000)
+				_config.TimerWindowLeft = (int) Left;
+
+			if (Top != -32000)
+				_config.TimerWindowTop = (int) Top;
 		}
 
 		private void MetroWindow_Activated(object sender, EventArgs e)


### PR DESCRIPTION
Haven't really tested this yet, but I think this should fix it.

If you want to hold off merging it that's ok. I'll do some testing on it now.

I decided to add the checks on load for -32000 too. That way it will sort this problem out for anyone who experienced it, without having to do the winkey+right trick. We can probably wait a few versions and then safely remove those checks.
