### PR TITLE
Remove DeckStats.xml.old creation

### DIFF
--- a/Hearthstone Deck Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/MainWindow.xaml.cs
@@ -310,9 +310,6 @@ namespace Hearthstone_Deck_Tracker
 				using(var sr = new StreamWriter(filePath, false))
 					sr.WriteLine("<DeckStatsList></DeckStatsList>");
 			}
-			else if(!File.Exists(filePath + ".old"))
-				//the new playerdecks.xml wont work with versions below 0.2.19, make copy
-				File.Copy(_decksPath, filePath + ".old");
 		}
 
 		// Logic for dealing with legacy config file semantics


### PR DESCRIPTION
`DeckStats.xml.old` was being created by copying `PlayerDecks.xml`. Looks like a copy-paste error? No harm done by it but may as well remove it.
