### PR TITLE
Put class specific class first when sorting by mana cost.

### DIFF
--- a/Hearthstone Deck Tracker/Utility/Helper.cs
+++ b/Hearthstone Deck Tracker/Utility/Helper.cs
@@ -174,7 +174,7 @@ namespace Hearthstone_Deck_Tracker
 		{
 			if(collection == null) return;
 			var view1 = (CollectionView)CollectionViewSource.GetDefaultView(collection);
-			view1.SortDescriptions.Clear();
+            view1.SortDescriptions.Clear();
 
             if (classFirst)
             {
@@ -190,7 +190,7 @@ namespace Hearthstone_Deck_Tracker
                 view1.SortDescriptions.Add(new SortDescription("LocalizedName", ListSortDirection.Ascending));
                 view1.SortDescriptions.Add(new SortDescription("Type", ListSortDirection.Descending));                
             }
-		}
+        }
 
 		public static string DeckToIdString(Deck deck)
 		{


### PR DESCRIPTION
I'm not sure if the current sorting was the intended sorting but it's been bothering me that when finding the specific class minion, i need to scroll down before i see the class specific minion, meanwhile all class specific spells are always on top.

For example, when editing a priest deck, for the 1 mana cost cards, this is what it looks like:

http://imgur.com/iqmKKG6,dMUJ9O7,mW8Uf9I,Qy1jayr#0
1. Holy Smite
2. Inner Fire
3. Mind Vision
4. Power Word: Shield

..... (neutral 1 mana cost minions)
17. Northshire Cleric

this PR make the list sorted as this:

http://imgur.com/iqmKKG6,dMUJ9O7,mW8Uf9I,Qy1jayr#3
1. Holy Smite
2. Inner Fire
3. Mind Vision
4. Northshire Cleric
5. Power Word: Shield

..... (neutral 1 mana cost minions)

For the 2 mana cost for priest, this is the before:

http://imgur.com/iqmKKG6,dMUJ9O7,mW8Uf9I,Qy1jayr#1

and after:

http://imgur.com/iqmKKG6,dMUJ9O7,mW8Uf9I,Qy1jayr#2
