### PR TITLE
Issue #81 -- Play a sound when remaining time in turn = x

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -395,10 +395,16 @@ namespace Hearthstone_Deck_Tracker
 		public bool TimerWindowOnStartup = false;
 
 		[DefaultValue(null)]
-		public int? TimerWindowTop = null;
+        public int? TimerWindowTop = null;
 
-		[DefaultValue(false)]
-		public bool TimerWindowTopmost = false;
+        [DefaultValue(false)]
+        public bool TimerWindowTopmost = false;
+
+        [DefaultValue(false)]
+        public bool TimerAlert = false;
+
+        [DefaultValue(30)]
+        public int TimerAlertSeconds = 30;
 
 		[DefaultValue(false)]
 		public bool TimerWindowTopmostIfHsForeground = false;

--- a/Hearthstone Deck Tracker/FlyoutControls/Options.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options.xaml
@@ -22,7 +22,7 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <GroupBox Header="Additional Windows" Grid.Column="1" Grid.Row="0"
-                                  HorizontalAlignment="Center" VerticalAlignment="Top" Width="234" Height="275"
+                                  HorizontalAlignment="Center" VerticalAlignment="Top" Width="234" Height="305"
                                   Margin="11,0,1,0">
                             <StackPanel>
                                 <StackPanel Orientation="Horizontal">
@@ -58,6 +58,17 @@
                                           Margin="10,5,0,0" VerticalAlignment="Top"
                                           Checked="CheckboxTimerWindow_Checked"
                                           Unchecked="CheckboxTimerWindow_Unchecked" />
+
+                                <DockPanel Margin="10,5,10,0">
+
+                                    <CheckBox x:Name="CheckboxTimerAlert"
+                                              Content="Alert at X seconds" HorizontalAlignment="Left" Margin="0,5,0,0" ToolTip="Sound an alert and flash when you have X seconds remaining"
+                                              VerticalAlignment="Top" Checked="CheckboxTimerAlert_Checked" Unchecked="CheckboxTimerAlert_Unchecked" />
+                                    <TextBox x:Name="TextboxTimerAlert" 
+                                             HorizontalAlignment="Right" Height="23" HorizontalContentAlignment="Center"
+                                             Margin="10,0,0,0" TextWrapping="Wrap" Text="30" VerticalAlignment="Top"
+                                             Width="60" TextChanged="TextboxTimerAlert_TextChanged" PreviewTextInput="TextboxTimerAlert_PreviewTextInput"/>
+                                </DockPanel>
                                 <CheckBox x:Name="CheckboxTimerTopmost" Content="Topmost"
                                           HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top"
                                           Checked="CheckboxTimerTopmost_Checked"

--- a/Hearthstone Deck Tracker/FlyoutControls/Options.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options.xaml.cs
@@ -157,26 +157,42 @@ namespace Hearthstone_Deck_Tracker
 				Helper.MainWindow.OpponentWindow.Topmost = true;
 			}
 			SaveConfig(false);
-		}
+        }
 
-		private void CheckboxTimerTopmost_Checked(object sender, RoutedEventArgs e)
-		{
-			if(!_initialized) return;
-			Config.Instance.TimerWindowTopmost = true;
-			Helper.MainWindow.TimerWindow.Topmost = true;
-			CheckboxTimerTopmostHsForeground.IsEnabled = true;
-			SaveConfig(true);
-		}
+        private void CheckboxTimerAlert_Checked(object sender, RoutedEventArgs e)
+        {
+            if(!_initialized) return;
+            Config.Instance.TimerAlert = true;
+            TextboxTimerAlert.IsEnabled = true;
+            SaveConfig(false);
+        }
 
-		private void CheckboxTimerTopmost_Unchecked(object sender, RoutedEventArgs e)
-		{
-			if(!_initialized) return;
-			Config.Instance.TimerWindowTopmost = false;
-			Helper.MainWindow.TimerWindow.Topmost = false;
-			CheckboxTimerTopmostHsForeground.IsEnabled = false;
-			CheckboxTimerTopmostHsForeground.IsChecked = false;
-			SaveConfig(true);
-		}
+        private void CheckboxTimerAlert_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if(!_initialized) return;
+            Config.Instance.TimerAlert = false;
+            TextboxTimerAlert.IsEnabled = false;
+            SaveConfig(false);
+        }
+
+        private void CheckboxTimerTopmost_Checked(object sender, RoutedEventArgs e)
+        {
+            if(!_initialized) return;
+            Config.Instance.TimerWindowTopmost = true;
+            Helper.MainWindow.TimerWindow.Topmost = true;
+            CheckboxTimerTopmostHsForeground.IsEnabled = true;
+            SaveConfig(true);
+        }
+
+        private void CheckboxTimerTopmost_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if(!_initialized) return;
+            Config.Instance.TimerWindowTopmost = false;
+            Helper.MainWindow.TimerWindow.Topmost = false;
+            CheckboxTimerTopmostHsForeground.IsEnabled = false;
+            CheckboxTimerTopmostHsForeground.IsChecked = false;
+            SaveConfig(true);
+        }
 
 		private void CheckboxTimerWindow_Checked(object sender, RoutedEventArgs e)
 		{
@@ -430,17 +446,49 @@ namespace Hearthstone_Deck_Tracker
 			return brush;
 		}
 
-		private void TextboxCustomBackground_TextChanged(object sender, TextChangedEventArgs e)
-		{
-			if(!_initialized || ComboboxWindowBackground.SelectedItem.ToString() != "Custom") return;
-			var background = BackgroundFromHex();
-			if(background != null)
-			{
-				UpdateAdditionalWindowsBackground(background);
-				Config.Instance.WindowsBackgroundHex = TextboxCustomBackground.Text;
-				SaveConfig(false);
-			}
-		}
+        private void TextboxCustomBackground_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if(!_initialized || ComboboxWindowBackground.SelectedItem.ToString() != "Custom") return;
+            var background = BackgroundFromHex();
+            if(background != null)
+            {
+                UpdateAdditionalWindowsBackground(background);
+                Config.Instance.WindowsBackgroundHex = TextboxCustomBackground.Text;
+                SaveConfig(false);
+            }
+        }
+
+        private void TextboxTimerAlert_PreviewTextInput(object sender, System.Windows.Input.TextCompositionEventArgs e)
+        {
+            if (!char.IsDigit(e.Text, e.Text.Length - 1))
+            {
+                e.Handled = true;
+            }
+        }
+
+        private void TextboxTimerAlert_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if(!_initialized || CheckboxTimerAlert.IsChecked != true) return;
+            int mTimerAlertValue;
+            int.TryParse(TextboxTimerAlert.Text, out mTimerAlertValue);
+            if (mTimerAlertValue != null)
+            {
+                if (mTimerAlertValue < 0)
+                {
+                    TextboxTimerAlert.Text = "0";
+                    mTimerAlertValue = 0;
+                }
+
+                if (mTimerAlertValue > 90)
+                {
+                    TextboxTimerAlert.Text = "90";
+                    mTimerAlertValue = 90;
+                }
+
+                Config.Instance.TimerAlertSeconds = mTimerAlertValue;
+                SaveConfig(false);
+            }
+        }
 
 		private async void ComboboxLanguages_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{

--- a/Hearthstone Deck Tracker/TurnTimer.cs
+++ b/Hearthstone Deck Tracker/TurnTimer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Media;
 using System.Timers;
 
 namespace Hearthstone_Deck_Tracker
@@ -108,6 +109,19 @@ namespace Hearthstone_Deck_Tracker
 				new Action(() => Helper.MainWindow.Overlay.UpdateTurnTimer(timerEventArgs)));
 			Helper.MainWindow.TimerWindow.Dispatcher.BeginInvoke(
 				new Action(() => Helper.MainWindow.TimerWindow.Update(timerEventArgs)));
+
+            if (CurrentTurn == Turn.Player)
+                CheckForTimerAlarm();
 		}
+
+        private void CheckForTimerAlarm()
+        {
+            if (Config.Instance.TimerAlert)
+                if (Seconds == Config.Instance.TimerAlertSeconds)
+                {
+                    SystemSounds.Asterisk.Play();
+                    User32.FlashHs();
+                }
+        }
 	}
 }


### PR DESCRIPTION
This introduces the ability for a user to receive an audio alert and flash Hearthstone when their time left in a turn reaches X seconds. 
- Added Checkbox and Textbox controls to Options.xaml
- Added config values for Textbox (int) and Checkbox (bool)
- Added event handlers for both to limit input to digits as well as save values and disable textbox when unchecked
- Added a check during TimerTick to play sound and flash when it reaches their specified time on their turn
- Made everyone aware I have no idea how to format indentation when commiting from Visual Studio to Git. Would you mind sharing with me your settings for formatting so my contributions in the future won't look so sloppy (and possibly fix and re-request if this isn't up to par).
