### PR TITLE
Changed card search for boule de feu

### DIFF
--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -234,6 +234,8 @@ namespace Hearthstone_Deck_Tracker
 					//french
 				case "Éclair":
 					return cardName + " 3";
+                case "Boule de Feu":
+                    return cardName + "Horsley";
 
 				default:
 					return cardName;


### PR DESCRIPTION
When searching for "Boule de Feu", the function would return both
fireball and archmage antonidas. I added the artist name for fireball as
per request so that antonidas doesn't show up anymore.

I personally don't have Archmage Antonidas, so I haven't been able to
test this. Can someone confirm that it works?
