### PR TITLE
Add option to auto-archive arena decks after the run is over

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -94,6 +94,9 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(67.5)]
 		public double AttackIconOpponentHorizontalPosition = 67.5;
 
+		[DefaultValue(false)]
+		public bool AutoArchiveArenaDecks = false;
+
 		[DefaultValue(true)]
 		public bool AutoClearDeck = true;
 

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerGeneral.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerGeneral.xaml
@@ -126,6 +126,11 @@
                               HorizontalAlignment="Left" Margin="10,5,0,0"
                               VerticalAlignment="Top" Checked="CheckBoxShowLastPlayedDate_Checked"
                               Unchecked="CheckBoxShowLastPlayedDate_Unchecked" />
+                    <Separator Margin="0,5,0,0" Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}" />
+                    <CheckBox x:Name="CheckBoxAutoArchiveArenaDecks" Content="Archive Arena decks when run is over"
+							  HorizontalAlignment="Left" Margin="10,5,0,0"
+							  VerticalAlignment="Top" Checked="CheckBoxAutoArchiveArenaDecks_Checked"
+							  Unchecked="CheckBoxAutoArchiveArenaDecks_Unchecked"/>
                     <DockPanel Margin="35,5,10,0" Visibility="{Binding Path=IsChecked, ElementName=CheckBoxShowLastPlayedDate, Converter={StaticResource BoolToVisibilityConverter}}">
                         <ComboBox DockPanel.Dock="Right" Name="ComboBoxLastPlayedDateFormat"  Margin="5,0,0,0" Width="150" HorizontalAlignment="Left"
                               SelectionChanged="ComboBoxLastPlayedDateFormat_OnSelectionChanged" >

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerGeneral.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerGeneral.xaml.cs
@@ -283,6 +283,22 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			MessageDialogs.ShowRestartDialog();
 		}
 
+		private void CheckBoxAutoArchiveArenaDecks_Checked(object sender, RoutedEventArgs e)
+		{
+			if (!_initialized)
+				return;
+			Config.Instance.AutoArchiveArenaDecks = true;
+			Config.Save();
+		}
+
+		private void CheckBoxAutoArchiveArenaDecks_Unchecked(object sender, RoutedEventArgs e)
+		{
+			if (!_initialized)
+				return;
+			Config.Instance.AutoArchiveArenaDecks = false;
+			Config.Save();
+		}
+
 		private void ComboBoxLastPlayedDateFormat_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
 			if(!_initialized)

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -506,7 +506,9 @@ namespace Hearthstone_Deck_Tracker
 
 				_lastGame = _game.CurrentGameStats;
 				selectedDeck.DeckStats.AddGameResult(_lastGame);
-				if(Config.Instance.ArenaRewardDialog && selectedDeck.IsArenaRunCompleted.HasValue && selectedDeck.IsArenaRunCompleted.Value)
+
+				var isArenaRunCompleted = selectedDeck.IsArenaRunCompleted.HasValue && selectedDeck.IsArenaRunCompleted.Value;
+				if(Config.Instance.ArenaRewardDialog && isArenaRunCompleted)
 					_arenaRewardDialog = new ArenaRewardDialog(selectedDeck);
 
 				if(Config.Instance.ShowNoteDialogAfterGame && !Config.Instance.NoteDialogDelayed && !_showedNoteDialog)
@@ -523,6 +525,9 @@ namespace Hearthstone_Deck_Tracker
 					Log.Info("Automatically unarchiving deck " + selectedDeck.Name + " after assigning current game");
 					Core.MainWindow.ArchiveDeck(_assignedDeck, false);
 				}
+
+				if (Config.Instance.AutoArchiveArenaDecks && isArenaRunCompleted)
+					Core.MainWindow.ArchiveDeck(selectedDeck, true);
 
 				if(HearthStatsAPI.IsLoggedIn && Config.Instance.HearthStatsAutoUploadNewGames)
 				{


### PR DESCRIPTION
This partially addresses enhancement request #909: an option to automatically archive arena decks when the run is over is added to the Tracker settings under "General".

Automatic deletion would be easy to tack on as well, but I'm not sure that's actually a good idea in practice since deletion, unlike archiving, is a destructive action with various options possible (e.g. delete stats vs keep stats, etc). Popping up the usual warning/confirmation screens would mitigate the data loss risk, but then it's no longer really automatic anyway.