### PR TITLE
Added option to select Hearthstone Log directory

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -427,6 +427,9 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(@"C:\Program Files (x86)\Hearthstone")]
 		public string HearthstoneDirectory = @"C:\Program Files (x86)\Hearthstone";
 
+		[DefaultValue("Logs")]
+		public string HearthstoneLogsDirectory = "Logs";
+
 		[DefaultValue("Hearthstone")]
 		public string HearthstoneWindowName = "Hearthstone";
 

--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -428,7 +428,7 @@ namespace Hearthstone_Deck_Tracker
 		public string HearthstoneDirectory = @"C:\Program Files (x86)\Hearthstone";
 
 		[DefaultValue("Logs")]
-		public string HearthstoneLogsDirectory = "Logs";
+		public string HearthstoneLogsDirectoryName = "Logs";
 
 		[DefaultValue("Hearthstone")]
 		public string HearthstoneWindowName = "Hearthstone";

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml
@@ -124,6 +124,10 @@
                             Click="SelectSaveDataPath_Click"
                             Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"
                             Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}" />
+                    <Button Name="ButtonHearthstoneLogsDirectory" Margin="10,5,10,0" Content="set hearthstone log directory" 
+                            Click="ButtonHearthstoneLogsDirectory_Click"
+                            Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"
+                            Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}" />
                     <Button Name="ButtonRestart" Margin="10,15,10,0" Content="restart hdt"
                             Click="ButtonRestart_OnClick" />
                 </StackPanel>

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml.cs
@@ -415,5 +415,32 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			Config.Instance.AlternativeScreenCapture = false;
 			Config.Save();
 		}
+
+		private async void ButtonHearthstoneLogsDirectory_Click(object sender, RoutedEventArgs e)
+		{
+			var dialog = new FolderBrowserDialog();
+			dialog.SelectedPath = Config.Instance.HearthstoneDirectory;
+			var dialogResult = dialog.ShowDialog();
+
+			if (dialogResult == DialogResult.OK)
+			{
+				//Logs directory needs to be a child directory in Hearthstone directory
+				if (!dialog.SelectedPath.StartsWith(Config.Instance.HearthstoneDirectory + @"\"))
+				{
+					await Core.MainWindow.ShowMessage("Invalid argument", "Selected directory not in Hearthstone directory!");
+					return;
+				}
+
+				//Check if same path selected (no restart required)
+				if (Config.Instance.HearthstoneLogsDirectoryName.Equals(dialog.SelectedPath))
+					return;
+
+				Config.Instance.HearthstoneLogsDirectoryName = dialog.SelectedPath.Remove(0, Config.Instance.HearthstoneDirectory.Length + 1);
+				Config.Save();
+
+				await Core.MainWindow.ShowMessage("Restart required.", "Click ok to restart HDT");
+				Core.MainWindow.Restart();
+			}
+		}
 	}
 }

--- a/Hearthstone Deck Tracker/LogReader/LogReader.cs
+++ b/Hearthstone Deck Tracker/LogReader/LogReader.cs
@@ -32,7 +32,7 @@ namespace Hearthstone_Deck_Tracker.LogReader
 		{
 			Info = info;
 			_filePath = string.IsNullOrEmpty(info.FilePath)
-				            ? Path.Combine(Config.Instance.HearthstoneDirectory, $"Logs/{Info.Name}.log") : info.FilePath;
+				            ? Path.Combine(Config.Instance.HearthstoneDirectory, Config.Instance.HearthstoneLogsDirectory, $"{Info.Name}.log") : info.FilePath;
 		}
 
 		public void Start(DateTime startingPoint)

--- a/Hearthstone Deck Tracker/LogReader/LogReader.cs
+++ b/Hearthstone Deck Tracker/LogReader/LogReader.cs
@@ -32,7 +32,7 @@ namespace Hearthstone_Deck_Tracker.LogReader
 		{
 			Info = info;
 			_filePath = string.IsNullOrEmpty(info.FilePath)
-				            ? Path.Combine(Config.Instance.HearthstoneDirectory, Config.Instance.HearthstoneLogsDirectory, $"{Info.Name}.log") : info.FilePath;
+				            ? Path.Combine(Config.Instance.HearthstoneDirectory, Config.Instance.HearthstoneLogsDirectoryName, $"{Info.Name}.log") : info.FilePath;
 		}
 
 		public void Start(DateTime startingPoint)


### PR DESCRIPTION
Currently, the Hearthstone Log directory is only dependent on the Hearthstone directory (logs can be found in \Logs). 

The purpose of this change is to provide functionality for Hearthstone multiboxing having a separate tracker window for every hearthstone instance. This is a feature I'm currently working on which will be provided as a plugin at some point.

Changes:
- Logs directory can now be changed to a different Log directory.