### PR TITLE
Fix potential error importing from clipboard

### DIFF
--- a/HDTTests/HDTTests.csproj
+++ b/HDTTests/HDTTests.csproj
@@ -54,7 +54,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -67,6 +69,7 @@
     <Compile Include="BoardDamage\EntityHelperTest.cs" />
     <Compile Include="HearthStats\ApiTest.cs" />
     <Compile Include="Hearthstone\GameTimeTest.cs" />
+    <Compile Include="Hearthstone\ParseCardStringTest.cs" />
     <Compile Include="Hearthstone\SecretTests.cs" />
     <Compile Include="Hearthstone\WebImportTest.cs" />
     <Compile Include="Hearthstone\DeckTest.cs" />

--- a/HDTTests/Hearthstone/ParseCardStringTest.cs
+++ b/HDTTests/Hearthstone/ParseCardStringTest.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using Hearthstone_Deck_Tracker;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HDTTests.Hearthstone
+{
+	[TestClass]
+	public class ParseCardStringTest
+	{
+		[TestMethod]
+		public void TestNoCount()
+		{
+			var deck = Helper.ParseCardString("Ragnaros the firelord");
+			var card = deck.Cards.FirstOrDefault();
+			Assert.AreEqual("EX1_298", card.Id);
+			Assert.AreEqual(1, card.Count);
+		}
+
+		[TestMethod]
+		public void TestOneCount()
+		{
+			var deck = Helper.ParseCardString("Ragnaros the firelord x1");
+			var card = deck.Cards.FirstOrDefault();
+			Assert.AreEqual("EX1_298", card.Id);
+			Assert.AreEqual(1, card.Count);
+		}
+
+		[TestMethod]
+		public void TestTwoCount()
+		{
+			var deck = Helper.ParseCardString("Ragnaros the firelord x2");
+			var card = deck.Cards.FirstOrDefault();
+			Assert.AreEqual("EX1_298", card.Id);
+			Assert.AreEqual(2, card.Count);
+		}
+
+		[TestMethod]
+		public void TestCommaNoCount()
+		{
+			var deck = Helper.ParseCardString("Ragnaros, Lightlord");
+			var card = deck.Cards.FirstOrDefault();
+			Assert.AreEqual("OG_229", card.Id);
+			Assert.AreEqual(1, card.Count);
+		}
+
+		[TestMethod]
+		public void TestCommaOneCount()
+		{
+			var deck = Helper.ParseCardString("Ragnaros, Lightlord x1");
+			var card = deck.Cards.FirstOrDefault();
+			Assert.AreEqual("OG_229", card.Id);
+			Assert.AreEqual(1, card.Count);
+		}
+
+		[TestMethod]
+		public void TestCommaTwoCount()
+		{
+			var deck = Helper.ParseCardString("Ragnaros, Lightlord x2");
+			var card = deck.Cards.FirstOrDefault();
+			Assert.AreEqual("OG_229", card.Id);
+			Assert.AreEqual(2, card.Count);
+		}
+	}
+}

--- a/Hearthstone Deck Tracker/Utility/Helper.cs
+++ b/Hearthstone Deck Tracker/Utility/Helper.cs
@@ -85,9 +85,9 @@ namespace Hearthstone_Deck_Tracker
 
 		private static bool? _hearthstoneDirExists;
 
-		private static readonly Regex CardLineRegexCountFirst = new Regex(@"(^(\s*)(?<count>\d)(\s*x)?\s+)(?<cardname>[\w\s'\.:!-]+)");
-		private static readonly Regex CardLineRegexCountLast = new Regex(@"(?<cardname>[\w\s'\.:!-]+)(\s+(x\s*)(?<count>\d))(\s*)$");
-		private static readonly Regex CardLineRegexCountLast2 = new Regex(@"(?<cardname>[\w\s'\.:!-]+)(\s+(?<count>\d))(\s*)$");
+		private static readonly Regex CardLineRegexCountFirst = new Regex(@"(^(\s*)(?<count>\d)(\s*x)?\s+)(?<cardname>[\w\s'\.:!-,]+)");
+		private static readonly Regex CardLineRegexCountLast = new Regex(@"(?<cardname>[\w\s'\.:!-,]+)(\s+(x\s*)(?<count>\d))(\s*)$");
+		private static readonly Regex CardLineRegexCountLast2 = new Regex(@"(?<cardname>[\w\s'\.:!-,]+)(\s+(?<count>\d))(\s*)$");
 
 		public static Dictionary<string, MediaColor> ClassicClassColors = new Dictionary<string, MediaColor>
 		{


### PR DESCRIPTION
A very small thing I noticed. 
If you import a deck from the clipboard and a card has a comma in its name and you use a count with it (e.g. 'Ragnaros, Lightlord x1'), it won't be recognized.
Since only legendaries have commas currently, this will probably never actually cause a problem though :smile:.
