### PR TITLE
Add nuget.config to override any existing repository path

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositoryPath" value=".\packages" />
+  </config>
+</configuration>


### PR DESCRIPTION
I've added a nuget.config file to make sure the package repository matches the path that all the projects' references are looking for.

In my case this was preventing me from building the solution because I have a global repository specified in my user-level nuget.config.  (Don't ask -- it's how I have to have things configured for my job.)  So a bunch of references end up broken when I try to build because the nuget packages get restored to the wrong place.  This change ensures that for this solution, nuget packages get restored into the local /packages dir.