### PR TITLE
Adding checkbox to import All/None in constructed (#Issue 2707)

### DIFF
--- a/Hearthstone Deck Tracker/Controls/DeckImportingControl.xaml
+++ b/Hearthstone Deck Tracker/Controls/DeckImportingControl.xaml
@@ -26,7 +26,7 @@
             <Border BorderThickness="1" BorderBrush="{DynamicResource AccentColorBrush}" HorizontalAlignment="Center" Margin="5">
                 <DockPanel Margin="0,0,0,5">
                     <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
-                        <CheckBox Name="ImportAllChk" IsChecked="True" Margin="5,0,0,0" Unchecked="onImportAll_Modified" Checked="onImportAll_Modified"/>
+                        <CheckBox Name="CheckBoxImportAll" IsChecked="True" Margin="5,0,0,0" Unchecked="CheckBoxImportAll_OnModified" Checked="CheckBoxImportAll_OnModified"/>
                         <Label Content="DECK" Margin="120,0,0,0" FontWeight="SemiBold"/>
                         <Label Content="SAVE TO" Margin="160,0,0,0" FontWeight="SemiBold"/>
                     </StackPanel>

--- a/Hearthstone Deck Tracker/Controls/DeckImportingControl.xaml
+++ b/Hearthstone Deck Tracker/Controls/DeckImportingControl.xaml
@@ -26,15 +26,16 @@
             <Border BorderThickness="1" BorderBrush="{DynamicResource AccentColorBrush}" HorizontalAlignment="Center" Margin="5">
                 <DockPanel Margin="0,0,0,5">
                     <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
+                        <CheckBox Name="ImportAllChk" IsChecked="True" Margin="5,0,0,0" Unchecked="onImportAll_Modified" Checked="onImportAll_Modified"/>
                         <Label Content="DECK" Margin="120,0,0,0" FontWeight="SemiBold"/>
                         <Label Content="SAVE TO" Margin="160,0,0,0" FontWeight="SemiBold"/>
                     </StackPanel>
                     <Separator DockPanel.Dock="Top"/>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <ItemsControl ItemsSource="{Binding Decks}" Margin="0,0,5,0">
+                        <ItemsControl Name="ItemsControl" ItemsSource="{Binding Decks}" Margin="0,0,5,0">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <CheckBox Name="CheckBoxImport"  IsChecked="{Binding Import}" Margin="5,0,0,0">
+                                    <CheckBox Name="CheckBoxImport" IsChecked="{Binding Import}" Margin="5,0,0,0">
                                         <DockPanel Height="30" IsEnabled="{Binding IsChecked, ElementName=CheckBoxImport}" >
                                             <Image Source="{Binding ClassImage}" Width="32" Height="32" RenderOptions.BitmapScalingMode="Fant"/>
                                             <TextBlock Text="{Binding Deck.Name}" VerticalAlignment="Center" Margin="5,0,0,0" FontWeight="SemiBold" FontSize="16" Width="200" TextTrimming="CharacterEllipsis"/>

--- a/Hearthstone Deck Tracker/Controls/DeckImportingControl.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/DeckImportingControl.xaml.cs
@@ -10,6 +10,7 @@ using Hearthstone_Deck_Tracker.Annotations;
 using Hearthstone_Deck_Tracker.Importing.Game;
 using Hearthstone_Deck_Tracker.Utility.Extensions;
 using static System.Windows.Visibility;
+using System.Windows.Controls;
 
 namespace Hearthstone_Deck_Tracker.Controls
 {
@@ -97,6 +98,20 @@ namespace Hearthstone_Deck_Tracker.Controls
 			OnPropertyChanged(nameof(ContentVisibility));
 			OnPropertyChanged(nameof(StartButtonVisibility));
 		}
+
+        private void onImportAll_Modified(object sender, RoutedEventArgs e)
+        {
+            if (ItemsControl != null)
+            {
+                for (int i = 0; i < ItemsControl.Items.Count; i++)
+                {
+                    ContentPresenter c = (ContentPresenter)ItemsControl.ItemContainerGenerator.ContainerFromItem(ItemsControl.Items[i]);
+                    CheckBox chk = c.ContentTemplate.FindName("CheckBoxImport", c) as CheckBox;
+                    chk.IsChecked = (bool)ImportAllChk.IsChecked;
+
+                }
+            }
+        }
 
 		public void StartedGame()
 		{

--- a/Hearthstone Deck Tracker/Controls/DeckImportingControl.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/DeckImportingControl.xaml.cs
@@ -99,19 +99,17 @@ namespace Hearthstone_Deck_Tracker.Controls
 			OnPropertyChanged(nameof(StartButtonVisibility));
 		}
 
-        private void onImportAll_Modified(object sender, RoutedEventArgs e)
-        {
-            if (ItemsControl != null)
-            {
-                for (int i = 0; i < ItemsControl.Items.Count; i++)
-                {
-                    ContentPresenter c = (ContentPresenter)ItemsControl.ItemContainerGenerator.ContainerFromItem(ItemsControl.Items[i]);
-                    CheckBox chk = c.ContentTemplate.FindName("CheckBoxImport", c) as CheckBox;
-                    chk.IsChecked = (bool)ImportAllChk.IsChecked;
+		private void CheckBoxImportAll_OnModified(object sender, RoutedEventArgs e)
+		{
+			if (ItemsControl == null) return;
 
-                }
-            }
-        }
+			foreach (var item in ItemsControl.Items)
+			{
+				var c = (ContentPresenter)ItemsControl.ItemContainerGenerator.ContainerFromItem(item);
+				var chk = (CheckBox) c.ContentTemplate.FindName("CheckBoxImport", c);
+				chk.IsChecked = CheckBoxImportAll.IsChecked.HasValue && CheckBoxImportAll.IsChecked.Value;
+			}
+		}
 
 		public void StartedGame()
 		{


### PR DESCRIPTION
At Import from game every deck comes already selected, which is really
annoying if you only want to import a single deck.
This commit tries to solve this problem by adding a leader checkbox which
toogles or untoogles every other deck

closes #2707 