### PR TITLE
Add Tribal filter to deck creation menu

### DIFF
--- a/Hearthstone Deck Tracker/Windows/MainWindow.NewDeck.cs
+++ b/Hearthstone Deck Tracker/Windows/MainWindow.NewDeck.cs
@@ -38,6 +38,7 @@ namespace Hearthstone_Deck_Tracker.Windows
 			var selectedClass = _newDeck.Class;
 			string selectedNeutral;
 			string selectedManaCost;
+			string selectedTribe;
 			string selectedSet;
 			try
 			{
@@ -55,6 +56,14 @@ namespace Hearthstone_Deck_Tracker.Windows
 			catch(Exception)
 			{
 				selectedManaCost = "ALL";
+			}
+			try
+			{
+				selectedTribe = MenuFilterTribe.Items.Cast<RadioButton>().First(x => x.IsChecked.HasValue && x.IsChecked.Value).Content.ToString();
+			}
+			catch(Exception)
+			{
+				selectedTribe = "ALL";
 			}
 			try
 			{
@@ -92,6 +101,8 @@ namespace Hearthstone_Deck_Tracker.Windows
 
 					// mana filter
 					if(selectedManaCost != "ALL" && ((selectedManaCost != "9+" || card.Cost < 9) && (selectedManaCost != card.Cost.ToString())))
+						continue;
+					if(selectedTribe != "ALL" && !string.Equals(selectedTribe, card.Race, StringComparison.InvariantCultureIgnoreCase))
 						continue;
 					if(selectedSet != "ALL" && !string.Equals(selectedSet, card.Set, StringComparison.InvariantCultureIgnoreCase))
 						continue;

--- a/Hearthstone Deck Tracker/Windows/MainWindow.xaml
+++ b/Hearthstone Deck Tracker/Windows/MainWindow.xaml
@@ -523,6 +523,17 @@
                         <RadioButton Content="CLASS ONLY" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />
                         <RadioButton Content="NEUTRAL ONLY" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />
                     </MenuItem>
+                    <MenuItem Name="MenuFilterTribe" Header="TRIBE">
+                        <RadioButton Content="ALL" IsChecked="True" Click="BtnFilter_OnClick" Margin="-24,0,0,0"
+                                     FontSize="14" />
+                        <RadioButton Content="BEAST" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />
+                        <RadioButton Content="DEMON" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />
+                        <RadioButton Content="DRAGON" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />
+                        <RadioButton Content="MECH" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />
+                        <RadioButton Content="MURLOC" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />
+                        <RadioButton Content="PIRATE" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />
+                        <RadioButton Content="TOTEM" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />
+                    </MenuItem>
                     <MenuItem Name="MenuFilterSet" Header="SET">
                         <RadioButton Content="ALL" IsChecked="True" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />
                         <RadioButton Content="BASIC" Click="BtnFilter_OnClick" Margin="-24,0,0,0" FontSize="14" />


### PR DESCRIPTION
Simply adds another filter for deck creation to filter by the Tribal tags.  The HearthDb stuff calls this "Race" but everywhere else I've seen Tribe.  Changing it to Race would be trivial obviously, but with the addition of more sets and more emphasis on some synergies I think it is a good option to have.  For example, if you want to make a Beast Druid with the new cards you can filter for cards of Beast type now.  Or Pirates, or Murlocs, or Dragons, etc.
