### PR TITLE
Show Opponent deck in the note window

### DIFF
--- a/Hearthstone Deck Tracker/Windows/NoteDialog.xaml
+++ b/Hearthstone Deck Tracker/Windows/NoteDialog.xaml
@@ -2,13 +2,64 @@
                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
-                      Title="NOTE FOR THIS GAME" Height="205" Width="439" Topmost="True" WindowStyle="ToolWindow"
+                      Title="NOTE FOR THIS GAME" Height="240" Width="440" Topmost="True" WindowStyle="ToolWindow"
                       Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
                       BorderBrush="{DynamicResource AccentColorBrush}" BorderThickness="1"
                       WindowStartupLocation="CenterScreen">
     <Grid>
-        <Button Content="Set" Margin="10,140,158,0" VerticalAlignment="Top" Click="Button_Click"/>
-        <TextBox Name="TextBoxNote" controls:TextBoxHelper.Watermark="Note..." Height="125" Margin="10,10,10,0"  PreviewKeyDown="TextBoxNote_OnPreviewKeyDown" TextWrapping="Wrap" Text="" VerticalAlignment="Top"/>
-        <CheckBox Name="CheckBoxEnterToSave" Content="Save with ENTER" HorizontalAlignment="Right" Margin="0,0,10,10" Width="123" Checked="CheckBoxEnterToSave_OnChecked" Unchecked="CheckBoxEnterToSave_OnUnchecked" VerticalAlignment="Bottom"/>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBox x:Name="TextBoxNote" Text=""
+                 Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"
+                 Margin="10,10,10,0"
+                 TextWrapping="Wrap"
+                 controls:TextBoxHelper.Watermark="Note..."
+                 PreviewKeyDown="TextBoxNote_OnPreviewKeyDown" />
+
+        <Border x:Name="DeckListContainer" Visibility="Collapsed" 
+                Grid.Column="3" Grid.Row="0"
+                Margin="0,10,10,0"
+                BorderThickness="1" BorderBrush="Black">
+            <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                <ItemsControl x:Name="DeckList">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <DockPanel Margin="4,2">
+                                <TextBlock DockPanel.Dock="Right"
+                                           Text="{Binding CountText}" Foreground="{Binding TextColor}" />
+                                <TextBlock Text="{Binding Name}" Foreground="{Binding TextColor}" />
+                            </DockPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+        
+        <Button x:Name="BtnSave" Content="Set"
+                Grid.Row="1" Grid.Column="0"
+                VerticalAlignment="Center"
+                Click="Button_Click" Margin="10,10,0,10" />
+
+        <CheckBox Name="CheckBoxEnterToSave"
+                  Grid.Row="1" Grid.Column="1"
+                  Content="Save with ENTER"
+                  HorizontalAlignment="Left"
+                  Checked="CheckBoxEnterToSave_OnChecked"
+                  Unchecked="CheckBoxEnterToSave_OnUnchecked"
+                  VerticalAlignment="Center" Margin="10,0,0,0" />
+
+        <Button x:Name="BtnDeck" Content="SHOW OPP DECK"
+                Grid.Row="1" Grid.Column="3"
+                Margin="0,10,10,10"
+                VerticalAlignment="Center"
+                Click="BtnDeck_Click" />
     </Grid>
 </controls:MetroWindow>

--- a/Hearthstone Deck Tracker/Windows/NoteDialog.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/NoteDialog.xaml.cs
@@ -1,8 +1,14 @@
 ﻿#region
 
+using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
+using HearthDb;
 using Hearthstone_Deck_Tracker.Stats;
+using static HearthDb.CardIds;
+using static System.Windows.Visibility;
 
 #endregion
 
@@ -22,6 +28,9 @@ namespace Hearthstone_Deck_Tracker
 			_game = game;
 			CheckBoxEnterToSave.IsChecked = Config.Instance.EnterToSaveNote;
 			TextBoxNote.Text = game.Note;
+			DeckList.ItemsSource = game.OpponentCards
+				.Select(x => new NoteCard(x))
+				.OrderBy(x => x.Cost);
 			Show();
 			Activate();
 			TextBoxNote.Focus();
@@ -38,6 +47,23 @@ namespace Hearthstone_Deck_Tracker
 				DeckStatsList.Save();
 			}
 			Close();
+		}
+
+		private void DeckPanelVisibility(Visibility visibility, int span, string prefix)
+		{
+			DeckListContainer.Visibility = visibility;
+			TextBoxNote.SetValue(Grid.ColumnSpanProperty, span);
+			BtnDeck.Content = $"{prefix} OPP DECK";
+		}
+
+		private void BtnDeck_Click(object sender, RoutedEventArgs e)
+		{
+			if(DeckListContainer.Visibility == Visible)
+				DeckPanelVisibility(Collapsed, 3, "SHOW");
+			else
+				DeckPanelVisibility(Visible, 2, "HIDE");
+
+			TextBoxNote.Focus();
 		}
 
 		private void TextBoxNote_OnPreviewKeyDown(object sender, KeyEventArgs e)
@@ -60,6 +86,37 @@ namespace Hearthstone_Deck_Tracker
 				return;
 			Config.Instance.EnterToSaveNote = false;
 			Config.Save();
+		}
+
+		private class NoteCard
+		{
+			public string Name { get; }
+			public string CountText { get; }
+			public Brush TextColor { get; }
+			public int Cost { get; }
+
+			public NoteCard() : this(null)
+			{
+			}
+
+			public NoteCard(TrackedCard tracked)
+			{
+				Card card = null;
+				if(tracked == null || !Cards.All.ContainsKey(tracked.Id))
+				{
+					card = Cards.All[NonCollectible.Neutral.Noooooooooooo];
+					CountText = "x0";
+					TextColor = Brushes.Red;
+				}					
+				else
+				{
+					card = Cards.All[tracked.Id];
+					CountText = $"x{tracked.Count}";
+					TextColor = tracked.Unconfirmed == 0 ? Brushes.Black : Brushes.Red;
+				}
+				Name = card.Name;				
+				Cost = card.Cost;
+			}
 		}
 	}
 }


### PR DESCRIPTION
I did this for #2363, but thought I'd deleted the branch, found it again! I believe its worth adding, the text style list fits in with the window I think.

![note_dialog](https://cloud.githubusercontent.com/assets/5419653/17981665/89fc7c26-6afc-11e6-87ec-5959c3d4e1f9.png)
