### PR TITLE
Prevent Competitive Spirit from being prematurely greyed out

### DIFF
--- a/HDTTests/Hearthstone/SecretTests.cs
+++ b/HDTTests/Hearthstone/SecretTests.cs
@@ -211,9 +211,9 @@ namespace HDTTests.Hearthstone
         public void SingleSecret_MinionInPlay_OpponentTurnStart()
         {
             _opponentEntity.SetTag(GameTag.CURRENT_PLAYER, 1);
-	        _opponentMinion1.SetTag(GameTag.ZONE, (int)Zone.PLAY);
+            _opponentMinion1.SetTag(GameTag.ZONE, (int)Zone.PLAY);
             _gameEventHandler.HandleTurnsInPlayChange(_opponentMinion1, 1);
-			_opponentMinion1.SetTag(GameTag.ZONE, (int)Zone.INVALID);
+            _opponentMinion1.SetTag(GameTag.ZONE, (int)Zone.INVALID);
             VerifySecrets(0, HunterSecrets.All);
             VerifySecrets(1, MageSecrets.All);
             VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.CompetitiveSpirit);

--- a/HDTTests/Hearthstone/SecretTests.cs
+++ b/HDTTests/Hearthstone/SecretTests.cs
@@ -211,10 +211,19 @@ namespace HDTTests.Hearthstone
         public void SingleSecret_MinionInPlay_OpponentTurnStart()
         {
             _opponentEntity.SetTag(GameTag.CURRENT_PLAYER, 1);
+	        _opponentMinion1.SetTag(GameTag.ZONE, (int)Zone.PLAY);
             _gameEventHandler.HandleTurnsInPlayChange(_opponentMinion1, 1);
+			_opponentMinion1.SetTag(GameTag.ZONE, (int)Zone.INVALID);
             VerifySecrets(0, HunterSecrets.All);
             VerifySecrets(1, MageSecrets.All);
             VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.CompetitiveSpirit);
+        }
+
+        [TestMethod]
+        public void CompetitiveSpirit_NoMinionInPlay_OpponentTurnStart()
+        {
+            _gameEventHandler.HandleTurnsInPlayChange(_heroOpponent, 1);
+            VerifySecrets(2, PaladinSecrets.All);
         }
 
         [TestMethod]

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -264,7 +264,10 @@ namespace Hearthstone_Deck_Tracker
 				|| !entity.IsControlledBy(_game.Opponent.Id) || !_game.OpponentEntity.IsCurrentPlayer)
 				return;
 			_lastCompetitiveSpiritCheck = turn;
-			_game.OpponentSecrets.SetZero(Paladin.CompetitiveSpirit);
+
+			if(_game.OpponentMinionCount > 0)
+				_game.OpponentSecrets.SetZero(Paladin.CompetitiveSpirit);
+
 			if(Core.MainWindow != null)
 				Core.Overlay.ShowSecrets();
 		}


### PR DESCRIPTION
This addresses issue #2753 where if the opponent played Competitive Spirit, it would be greyed out regardless of opponent minion presence.