### PR TITLE
Add section about bootstrapping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,10 @@
 
 ## Contributing
 
+### Bootstrapping
+
+Run [bootstrap.bat](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/bootstrap.bat) before opening the solution in Visual Studio.
+
 ### Coding style
 
 1. Always use tabs.


### PR DESCRIPTION
New contributors might not notice the existence of bootstrap.bat and that
can lead to longer onboarding times. The fix is to mention this file in
contributing section.