### PR TITLE
Fix sorting constructed games by duration

### DIFF
--- a/Hearthstone Deck Tracker/Controls/Stats/Constructed/ConstructedGames.xaml
+++ b/Hearthstone Deck Tracker/Controls/Stats/Constructed/ConstructedGames.xaml
@@ -134,7 +134,7 @@
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
-                    <DataGridTextColumn Header="{lex:Loc Stats_Constructed_Games_Table_Duration}" Binding="{Binding Duration}" SortMemberPath="Duration">
+                    <DataGridTextColumn Header="{lex:Loc Stats_Constructed_Games_Table_Duration}" Binding="{Binding Duration}" SortMemberPath="SortableDuration">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="HorizontalAlignment" Value="Center" />


### PR DESCRIPTION
When sorting constructed games by duration it was comparing the string duration rather than the numeric duration.