### PR TITLE
Focus search box when form loads

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml
@@ -14,7 +14,7 @@
         <DockPanel>
             <DockPanel DockPanel.Dock="Top">
                 <Button Name="ButtonSearch" Content="{lex:Loc Options_Search_SearchButton}" Width="100" Margin="5,0,0,0" IsDefault="True" Click="ButtonSearch_OnClick" DockPanel.Dock="Right"/>
-                <TextBox Name="TextBoxSearch" controls:TextBoxHelper.Watermark="{lex:Loc Options_Search_TextBox_Watermark}"/>
+                <TextBox Name="TextBoxSearch" controls:TextBoxHelper.Watermark="{lex:Loc Options_Search_TextBox_Watermark}" Loaded="TextBoxSearchLoaded"/>
             </DockPanel>
             <ListBox Name="ListBoxSearchResult" Margin="0,5,0,0" MouseDoubleClick="ListBoxSearchResult_OnMouseDoubleClick"/>
         </DockPanel>

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
@@ -20,7 +20,6 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options
 		public OptionsSearch()
 		{
 			InitializeComponent();
-			TextBoxSearch.Loaded += TextBoxSearchLoaded;
 		}
 		
 		private void TextBoxSearchLoaded(object sender, RoutedEventArgs routedEventArgs)

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
@@ -20,6 +20,12 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options
 		public OptionsSearch()
 		{
 			InitializeComponent();
+			TextBoxSearch.Loaded += TextBoxSearchLoaded;
+		}
+		
+		private void TextBoxSearchLoaded(object sender, RoutedEventArgs routedEventArgs)
+		{
+			((TextBox) sender).Focus();
 		}
 
 		private List<CheckBoxWrapper> CheckBoxWrappers => _checkBoxWrappers ?? (_checkBoxWrappers = LoadWrappers());


### PR DESCRIPTION
When search is clicked, the text box will auto-focus so the user doesn't have to click on it themselves. 

As always, demonstration: https://www.youtube.com/watch?v=2x4lAIbAoQo 