### PR TITLE
Search tab updates with search results as user types

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml
@@ -14,7 +14,7 @@
         <DockPanel>
             <DockPanel DockPanel.Dock="Top">
                 <Button Name="ButtonSearch" Content="{lex:Loc Options_Search_SearchButton}" Width="100" Margin="5,0,0,0" IsDefault="True" Click="ButtonSearch_OnClick" DockPanel.Dock="Right"/>
-                <TextBox Name="TextBoxSearch" controls:TextBoxHelper.Watermark="{lex:Loc Options_Search_TextBox_Watermark}" Loaded="TextBoxSearchLoaded"/>
+                <TextBox Name="TextBoxSearch" controls:TextBoxHelper.Watermark="{lex:Loc Options_Search_TextBox_Watermark}" Loaded="TextBoxSearchLoaded" TextChanged="TextBoxSearch_TextChanged"/>
             </DockPanel>
             <ListBox Name="ListBoxSearchResult" Margin="0,5,0,0" MouseDoubleClick="ListBoxSearchResult_OnMouseDoubleClick"/>
         </DockPanel>

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
@@ -1,5 +1,6 @@
 ﻿#region
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
@@ -29,7 +30,8 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options
 
 		private List<CheckBoxWrapper> CheckBoxWrappers => _checkBoxWrappers ?? (_checkBoxWrappers = LoadWrappers());
 
-		private void ButtonSearch_OnClick(object sender, RoutedEventArgs e) => UpdateSearchResult(TextBoxSearch.Text);
+        //Keep in mind TextBoxSearch_TextChanged will call this with its own eventargs if you decide to modify this
+        private void ButtonSearch_OnClick(object sender, RoutedEventArgs e) => UpdateSearchResult(TextBoxSearch.Text);
 
 		private List<CheckBoxWrapper> LoadWrappers()
 		{
@@ -103,5 +105,12 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options
 			public UserControl UserControl { get; set; }
 			public string Name { get; set; }
 		}
-	}
+
+        private void TextBoxSearch_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (TextBoxSearch.Text.Length < 3)
+                return;
+            ButtonSearch_OnClick(ButtonSearch, e);
+        }
+    }
 }

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
@@ -29,7 +29,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options
 
 		private List<CheckBoxWrapper> CheckBoxWrappers => _checkBoxWrappers ?? (_checkBoxWrappers = LoadWrappers());
 
-        private void ButtonSearch_OnClick(object sender, RoutedEventArgs e) => UpdateSearchResult(TextBoxSearch.Text);
+		private void ButtonSearch_OnClick(object sender, RoutedEventArgs e) => UpdateSearchResult(TextBoxSearch.Text);
 
 		private List<CheckBoxWrapper> LoadWrappers()
 		{
@@ -104,11 +104,11 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options
 			public string Name { get; set; }
 		}
 
-        private void TextBoxSearch_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            if (TextBoxSearch.Text.Length < 3)
-                return;
-            UpdateSearchResult(TextBoxSearch.Text);
-        }
-    }
+		private void TextBoxSearch_TextChanged(object sender, TextChangedEventArgs e)
+		{
+			if (TextBoxSearch.Text.Length < 3)
+				return;
+			UpdateSearchResult(TextBoxSearch.Text);
+		}
+	}
 }

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
@@ -29,7 +29,6 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options
 
 		private List<CheckBoxWrapper> CheckBoxWrappers => _checkBoxWrappers ?? (_checkBoxWrappers = LoadWrappers());
 
-        //Keep in mind TextBoxSearch_TextChanged will call this with its own eventargs if you decide to modify this
         private void ButtonSearch_OnClick(object sender, RoutedEventArgs e) => UpdateSearchResult(TextBoxSearch.Text);
 
 		private List<CheckBoxWrapper> LoadWrappers()
@@ -109,7 +108,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options
         {
             if (TextBoxSearch.Text.Length < 3)
                 return;
-            ButtonSearch_OnClick(ButtonSearch, e);
+            UpdateSearchResult(TextBoxSearch.Text);
         }
     }
 }

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsSearch.xaml.cs
@@ -1,6 +1,5 @@
 ﻿#region
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;


### PR DESCRIPTION
The search tab will automatically update with search results as user types, as long as they have three or more characters in the text box. 

The search button can still be used for reasons of searching with 2 or less characters, however will probably not be used.