### PR TITLE
Cleanup events from disabled addons.

### DIFF
--- a/Hearthstone Deck Tracker/API/ActionList.cs
+++ b/Hearthstone Deck Tracker/API/ActionList.cs
@@ -35,7 +35,10 @@ namespace Hearthstone_Deck_Tracker.API
 				var sw = Stopwatch.StartNew();
 				var plugin = action.Item1 as PluginWrapper;
 				if(plugin != null && !plugin.IsEnabled)
+				{
+					remove.Add(action);
 					continue;
+				}
 				try
 				{
 					action.Item2.Invoke(arg);
@@ -83,7 +86,10 @@ namespace Hearthstone_Deck_Tracker.API
 				var sw = Stopwatch.StartNew();
 				var plugin = action.Item1 as PluginWrapper;
 				if(plugin != null && !plugin.IsEnabled)
+				{
+					remove.Add(action);
 					continue;
+				}
 				try
 				{
 					action.Item2.Invoke();


### PR DESCRIPTION
Events registered by disabled plugins should be removed from the ActionList. Disabled plugins shouldn't be able to receive events; if the plugin is disabled it shouldn't be doing anything. In addition the ActionList contains a reference back to the method the plugin passed in which, as there is no Remove method, will prevent the Object where the method is defined from being disposed when the addon is disabled creating a likely memory leak.