### PR TITLE
Reload Plugins

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:lex="http://wpflocalizeextension.codeplex.com"
+             xmlns:options="clr-namespace:Hearthstone_Deck_Tracker.FlyoutControls.Options"
              lex:LocalizeDictionary.DesignCulture="en"
              lex:ResxLocalizationProvider.DefaultAssembly="HearthstoneDeckTracker"
              lex:ResxLocalizationProvider.DefaultDictionary="Strings"
@@ -17,6 +18,7 @@
                     <StackPanel DockPanel.Dock="Right" Margin="5,0,0,0">
                         <Button Click="ButtonAvailablePlugins_OnClick" Content="{lex:Loc Options_Tracker_Plugins_Button_Avilable}" />
                         <Button Click="ButtonOpenPluginsFolder_OnClick" Content="{lex:Loc Options_Tracker_Plugins_Button_Folder}" Margin="0,5,0,0" />
+                        <Button Click="ButtonReloadPlugins_OnClick" Content="{lex:Loc Options_Tracker_Plugins_Button_Reload}" Margin="0,5,0,0" Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}" />
                     </StackPanel>
                     <Border BorderThickness="1" BorderBrush="{DynamicResource AccentColorBrush}">
                         <ListBox Name="ListBoxPlugins" SelectionChanged="ListBoxPlugins_OnSelectionChanged"

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml
@@ -18,7 +18,12 @@
                     <StackPanel DockPanel.Dock="Right" Margin="5,0,0,0">
                         <Button Click="ButtonAvailablePlugins_OnClick" Content="{lex:Loc Options_Tracker_Plugins_Button_Avilable}" />
                         <Button Click="ButtonOpenPluginsFolder_OnClick" Content="{lex:Loc Options_Tracker_Plugins_Button_Folder}" Margin="0,5,0,0" />
-                        <Button Click="ButtonReloadPlugins_OnClick" Content="{lex:Loc Options_Tracker_Plugins_Button_Reload}" Margin="0,5,0,0" Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}" />
+                        <Button Click="ButtonReloadPlugins_OnClick" 
+                                Content="{lex:Loc Options_Tracker_Plugins_Button_Reload}" 
+                                Margin="0,5,0,0"
+                                Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}"
+                                Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"
+                                />
                     </StackPanel>
                     <Border BorderThickness="1" BorderBrush="{DynamicResource AccentColorBrush}">
                         <ListBox Name="ListBoxPlugins" SelectionChanged="ListBoxPlugins_OnSelectionChanged"

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
@@ -60,5 +60,10 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			}
 			Helper.TryOpenUrl(dir.FullName);
 		}
+
+		private void ButtonReloadPlugins_OnClick(object sender, RoutedEventArgs e)
+		{
+			Core.MainWindow.Restart();
+		}
 	}
 }

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
@@ -61,9 +61,6 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			Helper.TryOpenUrl(dir.FullName);
 		}
 
-		private void ButtonReloadPlugins_OnClick(object sender, RoutedEventArgs e)
-		{
-			Core.MainWindow.Restart();
-		}
+		private void ButtonReloadPlugins_OnClick(object sender, RoutedEventArgs e) => Core.MainWindow.Restart();
 	}
 }


### PR DESCRIPTION
Adds a reload plugins button under "plugins folder".

Currently it restarts HDT, this is likely a temporary solution until plugins are loaded within their own AppDomain.

It is only visible with "advanced options" turned on, as this feature is going to be most useful for developers testing plugins. A user likely won't need to continuously reload plugins.

Edit: strings will need to be updated. The name could either be "reload plugins" or "restart HDT", whichever is preferred.