### PR TITLE
Fix Mana Crystals Import Issue

### DIFF
--- a/Hearthstone Deck Tracker/Importing/Websites/Manacrystals.cs
+++ b/Hearthstone Deck Tracker/Importing/Websites/Manacrystals.cs
@@ -58,6 +58,10 @@ namespace Hearthstone_Deck_Tracker.Importing.Websites
 		private static void CardNodes(HtmlNode node, Deck deck)
 		{
 			var cardNodes = node.SelectNodes(".//ul/li");
+			if (cardNodes == null) 
+			{
+				return;
+			}
 			foreach (var cardNode in cardNodes)
 			{
 				var count = HttpUtility.HtmlDecode(


### PR DESCRIPTION
When Mana Crystals does not show a set of cards in either the class card or the neutral card sections of the website, a null pointer exception was thrown. 

This change should fix that issue. 