### PR TITLE
Drag and drop for plugins.

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml
@@ -11,7 +11,7 @@
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="300">
     <Grid>
-        <GroupBox Header="{lex:LocTextUpper Options_Tracker_Plugins_Header}">
+        <GroupBox Header="{lex:LocTextUpper Options_Tracker_Plugins_Header}" AllowDrop="True" Drop="GroupBox_Drop">
             <DockPanel>
                 <DockPanel DockPanel.Dock="Top" Height="150">
                     <StackPanel DockPanel.Dock="Right" Margin="5,0,0,0">

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
@@ -66,29 +66,29 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 		private async void GroupBox_Drop(object sender, DragEventArgs e)
 		{
 			var dir = PluginManager.PluginDirectory.FullName;
-			int plugins = 0;
 			try
 			{
 				if(e.Data.GetDataPresent(DataFormats.FileDrop))
 				{
-					string[] droppedFiles = (string[])e.Data.GetData(DataFormats.FileDrop);
-					if (droppedFiles == null) return;
+					
+					var plugins = 0;
+					var droppedFiles = (string[])e.Data.GetData(DataFormats.FileDrop);
+					if (droppedFiles == null) 
+						return;
 					foreach(var pluginPath in droppedFiles)
 					{
 						if (!pluginPath.EndsWith(".dll")) continue;
-						File.Copy(pluginPath, dir + "\\" + Path.GetFileName(pluginPath), true);
-						plugins += 1;
+						File.Copy(pluginPath, Path.Combine(dir, Path.GetFileName(pluginPath)), true);
+						plugins++;
 					}
-					if (plugins > 0)
-					{
-						var result = await Core.MainWindow.ShowMessageAsync("Plugins installed",
-							$"Successfully installed {plugins} plugins. \n Restart now to take effect?", MessageDialogStyle.AffirmativeAndNegative);
+					if (plugins <= 0) 
+						return;
+					var result = await Core.MainWindow.ShowMessageAsync("Plugins installed",
+						$"Successfully installed {plugins} plugin(s). \n Restart now to take effect?", MessageDialogStyle.AffirmativeAndNegative);
 
-						if (result == MessageDialogResult.Affirmative)
-						{
-							Core.MainWindow.Restart();
-						}
-					}
+					if (result != MessageDialogResult.Affirmative)
+						return;
+					Core.MainWindow.Restart();
 				}
 			}
 			catch(Exception ex)

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using Hearthstone_Deck_Tracker.Plugins;
@@ -77,9 +79,16 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 						return;
 					foreach(var pluginPath in droppedFiles)
 					{
-						if (!pluginPath.EndsWith(".dll")) continue;
-						File.Copy(pluginPath, Path.Combine(dir, Path.GetFileName(pluginPath)), true);
-						plugins++;
+						if(pluginPath.EndsWith(".dll"))
+						{
+							File.Copy(pluginPath, Path.Combine(dir, Path.GetFileName(pluginPath)), true);
+							plugins++;
+						}
+						else if(pluginPath.EndsWith(".zip"))
+						{
+							ZipFile.ExtractToDirectory(pluginPath, Path.Combine(dir, Path.GetFileNameWithoutExtension(pluginPath)));
+							plugins++;
+						}
 					}
 					if(plugins <= 0) 
 						return;

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
@@ -73,7 +73,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 					
 					var plugins = 0;
 					var droppedFiles = (string[])e.Data.GetData(DataFormats.FileDrop);
-					if (droppedFiles == null) 
+					if(droppedFiles == null) 
 						return;
 					foreach(var pluginPath in droppedFiles)
 					{
@@ -81,12 +81,12 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 						File.Copy(pluginPath, Path.Combine(dir, Path.GetFileName(pluginPath)), true);
 						plugins++;
 					}
-					if (plugins <= 0) 
+					if(plugins <= 0) 
 						return;
 					var result = await Core.MainWindow.ShowMessageAsync("Plugins installed",
 						$"Successfully installed {plugins} plugin(s). \n Restart now to take effect?", MessageDialogStyle.AffirmativeAndNegative);
 
-					if (result != MessageDialogResult.Affirmative)
+					if(result != MessageDialogResult.Affirmative)
 						return;
 					Core.MainWindow.Restart();
 				}

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerPlugins.xaml.cs
@@ -76,8 +76,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 					foreach(var pluginPath in droppedFiles)
 					{
 						if (!pluginPath.EndsWith(".dll")) continue;
-						if (File.Exists(dir + "\\" + Path.GetFileName(pluginPath))) continue;
-						File.Copy(pluginPath, dir + "\\" + Path.GetFileName(pluginPath));
+						File.Copy(pluginPath, dir + "\\" + Path.GetFileName(pluginPath), true);
 						plugins += 1;
 					}
 					if (plugins > 0)


### PR DESCRIPTION
This adds functionality to the plugins flyout control to easily install plugins. It checks for the files dropped ending in `.dll` and will overwrite the file if it is already in the folder (as if it's a plugin update).