### PR TITLE
Include importing for DisguisedToast.com

### DIFF
--- a/HDTTests/Hearthstone/WebImportTest.cs
+++ b/HDTTests/Hearthstone/WebImportTest.cs
@@ -135,6 +135,20 @@ namespace HDTTests.Hearthstone
 			Deck expected = CreateDeck("Inner Rage;2", "Shield Slam;2", "Grommash Hellscream;1", "Piloted Shredder;2",
 				"Dr. Boom;1", "Warsong Commander;0", "Slam;0", "Gnomish Inventor;0", "Emperor Thaurissan;0");
 			Deck found = DeckImporter.Import(@"https://manacrystals.com/decklists/172-zalae-s-patron-warrior").Result;
+			
+			Assert.IsTrue(AreDecksEqual(expected, found));
+		}
+
+		[TestMethod, TestCategory("Web")]
+		public void Disguisedtoast()
+		{
+			Deck expected = CreateDeck("Inner Rage;0", "Armorsmith;0", "Battle Rage;0", "Frothing Berserker;0", "Warsong Commander;0", 
+				"Death's Bite;0", "Dread Corsair;0", "Gnomish Inventor;0", "Shield Slam;2", "Grim Patron;0", "Whirlwind;1", "Cruel Taskmaster;1",
+				"Execute;2", "Fiery War Axe;2", "Emperor Thaurissan;0", "Unstable Ghoul;0",
+				"Revenge;2", "Slam;1", "Sleep with the Fishes;2", "Bash;2", "Ravaging Ghoul;2", "Shield Block;2", "Alley Armorsmith;2",
+				"Brawl;2", "Gorehowl;1", "Grommash Hellscream;1", "Dirty Rat;2", "Acolyte of Pain;1", "Justicar Trueheart;1", "Deathwing;1"
+				);
+			Deck found = DeckImporter.Import(@"https://disguisedtoast.com/decklists/2122-fibonacci-s-legend-control-warrior").Result;
 			Assert.IsTrue(AreDecksEqual(expected, found));
 		}
 
@@ -179,7 +193,17 @@ namespace HDTTests.Hearthstone
 				"Grommash Hellscream;0",
 				"Dr. Boom;0",
 				"Piloted Shredder;0",
-				"Shield Slam;0"
+				"Shield Slam;0",
+				"Revenge;0",
+				"Sleep with the Fishes;0",
+				"Bash;0",
+				"Ravaging Ghoul;0",
+				"Alley Armorsmith;0",
+				"Brawl;0",
+				"Gorehowl;0",
+				"Dirty Rat;0",
+				"Justicar Trueheart;0",
+				"Deathwing;0"
 			};
 
 			cardList = DefaultDeck(cardNames);

--- a/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
+++ b/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
@@ -399,6 +399,7 @@
       <DependentUpon>Warning.xaml</DependentUpon>
     </Compile>
     <Compile Include="Importing\StringImporter.cs" />
+    <Compile Include="Importing\Websites\Disguisedtoast.cs" />
     <Compile Include="Utility\RegistryHelper.cs" />
     <Compile Include="Hearthstone\Watchers.cs" />
     <Compile Include="HsReplay\PackDataGenerator.cs" />

--- a/Hearthstone Deck Tracker/Importing/DeckImporter.cs
+++ b/Hearthstone Deck Tracker/Importing/DeckImporter.cs
@@ -39,7 +39,8 @@ namespace Hearthstone_Deck_Tracker.Importing
 			{"icy-veins", Icyveins.Import},
 			{"hearthbuilder", Hearthbuilder.Import},
 			{"manacrystals", Manacrystals.Import},
-			{"powned", Powned.Import}
+			{"powned", Powned.Import},
+			{"disguisedtoast", Disguisedtoast.Import }
 		};
 
 		private const int BrawlDeckType = 6;

--- a/Hearthstone Deck Tracker/Importing/Websites/Disguisedtoast.cs
+++ b/Hearthstone Deck Tracker/Importing/Websites/Disguisedtoast.cs
@@ -1,0 +1,52 @@
+﻿#region
+
+using System;
+using System.Threading.Tasks;
+using System.Web;
+using System.Windows;
+using Hearthstone_Deck_Tracker.Hearthstone;
+using Hearthstone_Deck_Tracker.Utility.Logging;
+
+#endregion
+
+namespace Hearthstone_Deck_Tracker.Importing.Websites
+{
+	public static class Disguisedtoast
+	{
+		public static async Task<Deck> Import(string url)
+		{
+			try
+			{
+				var doc = await ImportingHelper.GetHtmlDoc(url);
+
+				var deck = new Deck();
+
+				var deckName =
+					HttpUtility.HtmlDecode(doc.DocumentNode.SelectSingleNode("//div[@class='dt-well-header']/h2").InnerText);
+				deck.Name = deckName;
+
+
+				var cardNodes = doc.DocumentNode.SelectNodes("//ul[contains(@class,'dt-cardlist')]/li");
+
+				foreach(var cardNode in cardNodes)
+				{
+					var name = HttpUtility.HtmlDecode(cardNode.SelectSingleNode(".//div[@class='dt-card-name']").InnerText);
+					var count = int.Parse(HttpUtility.HtmlDecode(cardNode.SelectSingleNode(".//div[@class='dt-card-quantity']").InnerText));
+
+					var card = Database.GetCardFromName(name.Replace("\n", ""));
+					card.Count = count;
+					deck.Cards.Add(card);
+					if(string.IsNullOrEmpty(deck.Class) && card.PlayerClass != "Neutral")
+						deck.Class = card.PlayerClass;
+				}
+
+				return deck;
+			}
+			catch(Exception e)
+			{
+				Log.Error(e);
+				return null;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Includes importing support for DisguisedToast.com decks and adds a unit test.

The unit test includes many cards due to there being no older decks on there that are similar to Patron/charge warrior.