### PR TITLE
Fixed Pre-Build Event Issues and Bootstrap / Resource Gen Errors

### DIFF
--- a/Hearthstone Deck Tracker.sln
+++ b/Hearthstone Deck Tracker.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hearthstone Deck Tracker", "Hearthstone Deck Tracker\Hearthstone Deck Tracker.csproj", "{E63A3F1C-E662-4E62-BE43-AF27CB9E953D}"
 EndProject
@@ -13,7 +13,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HDTUninstaller", "HDTUninst
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{239EBA5D-709C-446C-93FD-40BBF9D5CBBF}"
 	ProjectSection(SolutionItems) = preProject
+		bootstrap.bat = bootstrap.bat
 		lib\De.TorstenMandelkow.MetroChart.dll = lib\De.TorstenMandelkow.MetroChart.dll
+		generate_resources.bat = generate_resources.bat
 		lib\HearthDb.dll = lib\HearthDb.dll
 	EndProjectSection
 EndProject

--- a/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
+++ b/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
@@ -1200,6 +1200,7 @@
     </Compile>
     <Compile Include="Utility\Updating\Updater.Squirrel.cs" />
     <Compile Include="Utility\Updating\Updater.Default.cs" />
+    <None Include="Test.bat" />
     <Resource Include="Resources\hsreplay_logo_white.png" />
     <EmbeddedResource Include="Resources\CHANGELOG.md" />
     <EmbeddedResource Include="Properties\Strings.ja-JP.resx">
@@ -1315,6 +1316,7 @@
     <Resource Include="Resources\ClassIcons\General\BaseLight\all.png" />
     <Resource Include="Resources\ClassIcons\General\BaseLight\archived.png" />
     <Resource Include="Resources\ClassIcons\General\BaseDark\archived.png" />
+    <None Include="PreBuildEvent.bat" />
     <None Include="Resources\card-mark-coin.png" />
     <Resource Include="Utility\Markdown.Xaml\License.txt" />
     <Resource Include="Resources\cards.png" />
@@ -1394,36 +1396,9 @@
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>if exist $(SolutionDir)HearthDb (
-  git -C $(SolutionDir)HearthDb fetch
-  git -C $(SolutionDir)HearthDb reset --hard origin/master
-) else (
-  git clone --depth 1 https://github.com/HearthSim/HearthDb.git $(SolutionDir)HearthDb
-)
-if exist $(SolutionDir)HearthMirror (
-  git -C $(SolutionDir)HearthMirror fetch
-  git -C $(SolutionDir)HearthMirror reset --hard origin/master
-) else (
-  git clone --depth 1 https://github.com/HearthSim/HearthMirror.git $(SolutionDir)HearthMirror
-)
-if exist $(SolutionDir)HSReplay-Api (
-  git -C $(SolutionDir)HSReplay-Api fetch
-  git -C $(SolutionDir)HSReplay-Api reset --hard origin/master
-) else (
-  git clone --depth 1 https://github.com/HearthSim/HSReplay-API-Client.git $(SolutionDir)HSReplay-Api
-)
-if exist $(SolutionDir)HDT-Localization (
-  git -C $(SolutionDir)HDT-Localization fetch
-  git -C $(SolutionDir)HDT-Localization reset --hard origin/master
-) else (
-  git clone --depth 1 https://github.com/HearthSim/HDT-Localization.git $(SolutionDir)HDT-Localization
-)
-xcopy /Y "$(SolutionDir)HDT-Localization\*.resx" "$(ProjectDir)Properties\"
-mkdir "$(TargetDir)\Images\Tiles"
-mkdir "$(TargetDir)\Images\Themes"
-xcopy /E /Y /Q "$(SolutionDir)Resources\Generated\Tiles" "$(TargetDir)\Images\Tiles"
-xcopy /E /Y /Q "$(ProjectDir)Images\Themes" "$(TargetDir)\Images\Themes"
-xcopy /Y /Q "$(SolutionDir)CHANGELOG.md" "$(ProjectDir)Resources"</PreBuildEvent>
+    <PreBuildEvent>"$(ProjectDir)PreBuildEvent.bat" "$(ProjectDir)..\" "$(ProjectDir)" "$(ProjectDir)($OutDir)" 0 0  
+ 
+</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
+++ b/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
@@ -1200,7 +1200,6 @@
     </Compile>
     <Compile Include="Utility\Updating\Updater.Squirrel.cs" />
     <Compile Include="Utility\Updating\Updater.Default.cs" />
-    <None Include="Test.bat" />
     <Resource Include="Resources\hsreplay_logo_white.png" />
     <EmbeddedResource Include="Resources\CHANGELOG.md" />
     <EmbeddedResource Include="Properties\Strings.ja-JP.resx">
@@ -1400,7 +1399,7 @@
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>"$(ProjectDir)PreBuildEvent.bat" "$(ProjectDir)..\" "$(ProjectDir)" "$(ProjectDir)($OutDir)" 0 0  
+    <PreBuildEvent>"$(ProjectDir)PreBuildEvent.bat" "$(ProjectDir)..\" "$(ProjectDir)" "$(TargetDir)" 0 0  
  
 </PreBuildEvent>
   </PropertyGroup>

--- a/Hearthstone Deck Tracker/PreBuildEvent.bat
+++ b/Hearthstone Deck Tracker/PreBuildEvent.bat
@@ -102,9 +102,9 @@ if exist "%SolutionDir%Resources\Generated\Tiles" if exist "%TargetDir%Images\Ti
 	echo.
 )
 
-if exist "$%ProjectDir%Images\Themes" if exist "%TargetDir%Images\Themes" (
-	echo Copying Themes from "$%ProjectDir%Images\Themes" to "%TargetDir%Images\Themes"
-	xcopy /E /Y /Q "$%ProjectDir%Images\Themes" "%TargetDir%Images\Themes"
+if exist "%ProjectDir%Images\Themes" if exist "%TargetDir%Images\Themes" (
+	echo Copying Themes from "%ProjectDir%Images\Themes" to "%TargetDir%Images\Themes"
+	xcopy /E /Y /Q "%ProjectDir%Images\Themes" "%TargetDir%Images\Themes"
 	echo.
 )
 

--- a/Hearthstone Deck Tracker/PreBuildEvent.bat
+++ b/Hearthstone Deck Tracker/PreBuildEvent.bat
@@ -79,7 +79,7 @@ if %SkipResourceCopy% equ 1 (
 )
 
 if exist "%SolutionDir%HDT-Localization" if exist "%ProjectDir%Properties\" (
-	echo Copying Localization files from "%SolutionDir%HDT-Localization\*.resx" to "%ProjectDir%Properties\"
+	echo Copying Localization files from "%SolutionDir%HDT-Localization" to "%ProjectDir%Properties\"
 	xcopy /Y "%SolutionDir%HDT-Localization\*.resx" "%ProjectDir%Properties\"
 	echo.
 )
@@ -90,9 +90,9 @@ if not exist "%TargetDir%Images\Tiles" (
 	echo.
 )
 
-if not exist "%TargetDir%\Images\Themes" (
-	echo Creating missing directory "%TargetDir%\Images\Themes"
-	mkdir "%TargetDir%\Images\Themes"
+if not exist "%TargetDir%Images\Themes" (
+	echo Creating missing directory "%TargetDir%Images\Themes"
+	mkdir "%TargetDir%Images\Themes"
 	echo.
 )
 

--- a/Hearthstone Deck Tracker/PreBuildEvent.bat
+++ b/Hearthstone Deck Tracker/PreBuildEvent.bat
@@ -1,0 +1,121 @@
+@echo off
+
+set SolutionDir=%~dp1
+set ProjectDir=%~dp2
+set TargetDir=%~dp3
+set SkipGitSync=%4
+set SkipResourceCopy=%5
+
+if "%SkipGitSync%"=="" (set SkipGitSync=0)
+if "%SkipResourceCopy%"=="" (set SkipResourceCopy=0)
+
+echo SolutionDir=%SolutionDir%
+echo ProjectDir=%ProjectDir%
+echo TargetDir=%TargetDir%
+echo SkipGitSync=%SkipGitSync%
+echo SkipResourceCopy=%SkipResourceCopy%
+
+echo.
+echo.
+
+if %SkipGitSync% equ 1 if %SkipResourceCopy% equ 1 (
+	echo ** Skipping GitSync and Resource Copy
+	echo.
+	goto EndLabel
+) 
+
+if %SkipGitSync% equ 1 (
+	echo ** Skipping GitSync  
+	echo.
+	goto ResourceCopyLabel 
+)
+
+if exist %SolutionDir%HearthDb (
+  echo Updating %SolutionDir%HearthDb to origin/master
+  git -C %SolutionDir%HearthDb fetch
+  git -C %SolutionDir%HearthDb reset --hard origin/master
+) else (
+  git clone --depth 1 https://github.com/HearthSim/HearthDb.git %SolutionDir%HearthDb
+)
+
+echo.
+
+if exist %SolutionDir%HearthMirror (
+  echo Updating %SolutionDir%HearthMirror to origin/master
+  git -C %SolutionDir%HearthMirror fetch
+  git -C %SolutionDir%HearthMirror reset --hard origin/master
+) else (
+  git clone --depth 1 https://github.com/HearthSim/HearthMirror.git %SolutionDir%HearthMirror
+)
+
+echo.
+
+if exist %SolutionDir%HSReplay-Api (
+  echo Updating %SolutionDir%HSReplay-Api to origin/master
+  git -C %SolutionDir%HSReplay-Api fetch
+  git -C %SolutionDir%HSReplay-Api reset --hard origin/master
+) else (
+  git clone --depth 1 https://github.com/HearthSim/HSReplay-API-Client.git %SolutionDir%HSReplay-Api
+)
+
+echo.
+
+if exist %SolutionDir%HDT-Localization (
+  echo Updating %SolutionDir%HDT-Localization to origin/master
+  git -C %SolutionDir%HDT-Localization fetch
+  git -C %SolutionDir%HDT-Localization reset --hard origin/master
+) else (
+  git clone --depth 1 https://github.com/HearthSim/HDT-Localization.git %SolutionDir%HDT-Localization
+)
+
+echo.
+
+:ResourceCopyLabel
+
+if %SkipResourceCopy% equ 1 ( 
+  echo ** Skipping Resource Copy
+  echo.
+  goto EndLabel
+)
+
+if exist "%SolutionDir%HDT-Localization" if exist "%ProjectDir%Properties\" (
+	echo Copying Localization files from "%SolutionDir%HDT-Localization\*.resx" to "%ProjectDir%Properties\"
+	xcopy /Y "%SolutionDir%HDT-Localization\*.resx" "%ProjectDir%Properties\"
+	echo.
+)
+
+if not exist "%TargetDir%Images\Tiles" (
+	echo Creating missing directory "%TargetDir%Images\Tiles"
+	mkdir "%TargetDir%Images\Tiles"
+	echo.
+)
+
+if not exist "%TargetDir%\Images\Themes" (
+	echo Creating missing directory "%TargetDir%\Images\Themes"
+	mkdir "%TargetDir%\Images\Themes"
+	echo.
+)
+
+if exist "%SolutionDir%Resources\Generated\Tiles" if exist "%TargetDir%Images\Tiles" (
+	echo Copying Generated tiles from "%SolutionDir%Resources\Generated\Tiles" to "%TargetDir%Images\Tiles"
+	xcopy /E /Y /Q "%SolutionDir%Resources\Generated\Tiles" "%TargetDir%Images\Tiles"
+	echo.
+)
+
+if exist "$%ProjectDir%Images\Themes" if exist "%TargetDir%Images\Themes" (
+	echo Copying Themes from "$%ProjectDir%Images\Themes" to "%TargetDir%Images\Themes"
+	xcopy /E /Y /Q "$%ProjectDir%Images\Themes" "%TargetDir%Images\Themes"
+	echo.
+)
+
+if exist "%SolutionDir%CHANGELOG.md" if exist "%ProjectDir%Resources" (
+	echo Copying "%SolutionDir%CHANGELOG.md" to "%ProjectDir%Resources"
+	xcopy /Y /Q "%SolutionDir%CHANGELOG.md" "%ProjectDir%Resources"
+) 
+
+:EndLabel
+
+echo Completed.
+
+
+

--- a/Hearthstone Deck Tracker/Test.bat
+++ b/Hearthstone Deck Tracker/Test.bat
@@ -1,3 +1,0 @@
-@echo off
-
-PreBuildEvent.bat ..\ .\ .\bin\X86\Debug\  0 0 

--- a/Hearthstone Deck Tracker/Test.bat
+++ b/Hearthstone Deck Tracker/Test.bat
@@ -1,0 +1,3 @@
+@echo off
+
+PreBuildEvent.bat ..\ .\ .\bin\X86\Debug\  0 0 

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,4 +1,7 @@
-nuget restore
+@echo off
+
+msbuild /t:restore
+REM nuget restore
 git clone https://github.com/HearthSim/HearthDb HearthDb
 git clone https://github.com/HearthSim/HearthMirror HearthMirror
 git clone https://github.com/HearthSim/HSReplay-API-Client.git HSReplay-Api

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,7 +1,6 @@
 @echo off
 
-msbuild /t:restore
-REM nuget restore
+nuget restore
 git clone https://github.com/HearthSim/HearthDb HearthDb
 git clone https://github.com/HearthSim/HearthMirror HearthMirror
 git clone https://github.com/HearthSim/HSReplay-API-Client.git HSReplay-Api

--- a/generate_resources.bat
+++ b/generate_resources.bat
@@ -1,2 +1,4 @@
+@echo off
+
 msbuild /t:ResourceGenerator /p:Configuration=Debug
 .\ResourceGenerator\bin\x86\Debug\ResourceGenerator.exe .\Resources Tiles


### PR DESCRIPTION
Several batch files would throw errors in the original solution and cause problems when the HSDT projects were included in a 3rd party solution (usually a plugin). 

Added error checking to scripts to prevent execution of routines that were contingent upon a successful completion of the previous command.  

Added the ability to disable the PreBuildEvent if you so desired. Fixed missing nuget.exe for VS2017 by using msbuild's new integrated functionality. 

Also rocked a nice ^M in there somewhere. 