### PR TITLE
Current Tutorial leads to build errors.  This line fixes that

### DIFF
--- a/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
+++ b/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
@@ -1479,7 +1479,7 @@
   </Target>
   -->
   <Target Name="GenerateDesignerFiles">
-    <GenerateResource Sources="Properties/Strings.resx" StronglyTypedLanguage="C#" StronglyTypedClassName="Strings" StronglyTypedNamespace="Hearthstone_Deck_Tracker.Properties" StronglyTypedFileName="Properties/Strings.Designer.cs" OutputResources="Hearthstone_Deck_Tracker.Properties.Strings.resources" PublicClass="true">
+    <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" Sources="Properties/Strings.resx" StronglyTypedLanguage="C#" StronglyTypedClassName="Strings" StronglyTypedNamespace="Hearthstone_Deck_Tracker.Properties" StronglyTypedFileName="Properties/Strings.Designer.cs" OutputResources="Hearthstone_Deck_Tracker.Properties.Strings.resources" PublicClass="true">
     </GenerateResource>
     <Delete Files="Hearthstone_Deck_Tracker.Properties.Strings.resources" />
   </Target>


### PR DESCRIPTION
When I used the tutorial I had Hearthstone Deck Tracker.exe not found and resgen.exe not found.  This fixes that.  If this pull request is rejected, then could you change the tutorial to add what worked for me.  Go to HearthstoneDeckTRacker and unload project.  Edit HearthStone Deck Tracker .csproj.  Go twoards the bottom where you will find Target GenerateDesignerFiles.  Add SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)"
after the following Generate Resource.  It will look like this.
```
<Target Name="GenerateDesignerFiles">
    <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" Sources="Properties/Strings.resx" StronglyTypedLanguage="C#" StronglyTypedClassName="Strings" StronglyTypedNamespace="Hearthstone_Deck_Tracker.Properties" StronglyTypedFileName="Properties/Strings.Designer.cs" OutputResources="Hearthstone_Deck_Tracker.Properties.Strings.resources" PublicClass="true">
    </GenerateResource>
    <Delete Files="Hearthstone_Deck_Tracker.Properties.Strings.resources" />
  </Target>
  <Target Name="BeforeBuild">
    <CallTarget Targets="GenerateDesignerFiles" />
  </Target>
```