### PR TITLE
Fixes Mirror Entity edge case. 

### DIFF
--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -223,8 +223,11 @@ namespace Hearthstone_Deck_Tracker
 			//We might not know this for certain - requires additional tracking logic.
 			//TODO: _game.OpponentSecrets.SetZero(Hunter.HiddenCache);
 			_game.OpponentSecrets.SetZero(Hunter.Snipe);
-			_game.OpponentSecrets.SetZero(Mage.MirrorEntity);
-			_game.OpponentSecrets.SetZero(Mage.PotionOfPolymorph);
+
+            if (_game.OpponentMinionCount < _game.MaxNumberOfMinions)
+                    _game.OpponentSecrets.SetZero(Mage.MirrorEntity);
+
+            _game.OpponentSecrets.SetZero(Mage.PotionOfPolymorph);
 			_game.OpponentSecrets.SetZero(Paladin.Repentance);
 
 			if(Core.MainWindow != null)

--- a/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
@@ -49,8 +49,9 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		public int OpponentMinionCount => Entities.Count(x => (x.Value.IsInPlay && x.Value.IsMinion && x.Value.IsControlledBy(Opponent.Id)));
 		public int PlayerMinionCount => Entities.Count(x => (x.Value.IsInPlay && x.Value.IsMinion && x.Value.IsControlledBy(Player.Id)));
 		public int OpponentHandCount => Entities.Count(x => x.Value.IsInHand && x.Value.IsControlledBy(Opponent.Id));
+        public int MaxNumberOfMinions = 7;
 
-		public Player Player { get; set; }
+        public Player Player { get; set; }
 		public Player Opponent { get; set; }
 		public bool IsInMenu { get; set; }
 		public bool IsUsingPremade { get; set; }


### PR DESCRIPTION
https://github.com/HearthSim/Hearthstone-Deck-Tracker/issues/3253
Mirror entity will not gray out because player plays a minion and their opponent has 7 minions.