### PR TITLE
Fixes the ambiguity of the date in Arena and Brawl decks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ build/
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/
 
+# Visual Studio 2015 cache/options directory
+.vs/
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -131,11 +131,11 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(true)]
 		public bool DeckPickerCaps = true;
 
-		[DefaultValue("Arena {Date dd-MM hh:mm}")]
-		public string ArenaDeckNameTemplate = "Arena {Date dd-MM hh:mm}";
+		[DefaultValue("Arena {Date dd-MM HH:mm}")]
+		public string ArenaDeckNameTemplate = "Arena {Date dd-MM HH:mm}";
 
-		[DefaultValue("Brawl {Date dd-MM hh:mm}")]
-		public string BrawlDeckNameTemplate = "Brawl {Date dd-MM hh:mm}";
+		[DefaultValue("Brawl {Date dd-MM HH:mm}")]
+		public string BrawlDeckNameTemplate = "Brawl {Date dd-MM HH:mm}";
 
 		[DefaultValue(false)]
 		public bool BringHsToForeground = false;


### PR DESCRIPTION
Some of the issues mention it and it was annoying to see a deck named 'ARENA 07-06 03:15' when you played it at 15:15 (in the afternoon).

Also amended .gitignore to ignore the .vs folder where changes were showing up in git.