### PR TITLE
Add originalDeck parameter to DeckEditorViewModel.SetDeck (fix #3423)

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/DeckEditor/DeckEditorView.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/DeckEditor/DeckEditorView.xaml.cs
@@ -30,7 +30,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.DeckEditor
 			};
 		}
 
-		public void SetDeck(Deck deck, bool isNewDeck) => ((DeckEditorViewModel)DataContext).SetDeck(deck, isNewDeck);
+		public void SetDeck(Deck deck, bool isNewDeck, Deck originalDeck) => ((DeckEditorViewModel)DataContext).SetDeck(deck, isNewDeck, originalDeck);
 
 		public void SetCards(IEnumerable<Card> cards) => ((DeckEditorViewModel)DataContext).SetCards(cards);
 

--- a/Hearthstone Deck Tracker/FlyoutControls/DeckEditor/DeckEditorViewModel.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/DeckEditor/DeckEditorViewModel.cs
@@ -58,9 +58,10 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.DeckEditor
 
 		public IEnumerable<Card> Cards => Deck.Cards;
 
-		public void SetDeck(Deck deck, bool isNewDeck)
+		public void SetDeck(Deck deck, bool isNewDeck, Deck originalDeck)
 		{
 			Deck = deck;
+			_originalDeck = originalDeck ?? deck;
 			var hasSaveOp = !isNewDeck && !deck.IsArenaDeck;
 			SelectedSaveOperation = hasSaveOp ? SaveOperations[1] : null;
 			SaveOperationSelectionVisibility = hasSaveOp ? Visibility.Visible : Visibility.Collapsed;
@@ -71,7 +72,6 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.DeckEditor
 			get => _deck;
 			set
 			{
-				_originalDeck = value;
 				_deck = (Deck)value.Clone();
 				SetCards(value.GetSelectedDeckVersion().Cards);
 				OnPropertyChanged();

--- a/Hearthstone Deck Tracker/Windows/MainWindow.Edit.cs
+++ b/Hearthstone Deck Tracker/Windows/MainWindow.Edit.cs
@@ -275,7 +275,7 @@ namespace Hearthstone_Deck_Tracker.Windows
 			imported.Cards.Clear();
 			foreach(var card in deck.Cards)
 				imported.Cards.Add(card);
-			ShowDeckEditorFlyout(imported, false);
+			ShowDeckEditorFlyout(imported, false, existingDeck);
 			Helper.SortCardCollection(ListViewDeck.Items, Config.Instance.CardSortingClassFirst);
 			ManaCurveMyDecks.UpdateValues();
 

--- a/Hearthstone Deck Tracker/Windows/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/MainWindow.xaml.cs
@@ -564,11 +564,11 @@ namespace Hearthstone_Deck_Tracker.Windows
 
 		private void HyperlinkDevDiscord_OnClick(object sender, RoutedEventArgs e) => Helper.TryOpenUrl("https://discord.gg/hearthsim-devs");
 
-		public void ShowDeckEditorFlyout(Deck deck, bool isNewDeck)
+		public void ShowDeckEditorFlyout(Deck deck, bool isNewDeck, Deck originalDeck = null)
 		{
 			if(deck == null)
 				return;
-			DeckEditorFlyout.SetDeck(deck, isNewDeck);
+			DeckEditorFlyout.SetDeck(deck, isNewDeck, originalDeck);
 			FlyoutDeckEditor.IsOpen = true;
 		}
 


### PR DESCRIPTION
Before this change, the field _originalDeck in DeckEditorViewModel was set to the new deck even when isNewDeck is false. Now when SetDeck is called there are 3 cases:

isNewDeck = true (originalDeck ignored) --> creating new deck
isNewDeck = false, originalDeck = null --> editing old deck
isNewDeck = false, originalDeck = Object --> editing deck with a parent deck