### PR TITLE
Fix erroneously recording stats for spectator mode

### DIFF
--- a/Hearthstone Deck Tracker/LogReader/Handlers/PowerHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/PowerHandler.cs
@@ -205,7 +205,7 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 					}
 				}
 			}
-			if(logLine.Contains("End Spectator"))
+			if(logLine.Contains("End Spectator") && !game.IsInMenu)
 				gameState.GameHandler.HandleGameEnd();
 			else if(logLine.Contains("BLOCK_START"))
 			{


### PR DESCRIPTION
If stats recording for spectator mode games is disabled and an active deck
is selected after spectating a gane (e.g. by starting an arena game), the
spectated game is assigned to the active deck because the end of a 0 turn
game is detected erroneously. This commit prevents the detection of a 0
turn game while in menu.

Fixes #3343.