### PR TITLE
Remove Standard Arena Secret filter for Wild Arena Fest

### DIFF
--- a/HDTTests/Hearthstone/Secrets/SecretsManagerTest.cs
+++ b/HDTTests/Hearthstone/Secrets/SecretsManagerTest.cs
@@ -362,7 +362,7 @@ namespace HDTTests.Hearthstone.Secrets
 			game.CurrentGameType = GameType.GT_ARENA;
 			game.CurrentFormat = Format.Wild; // Arena format is Wild
 			cards = secretsManager.GetSecretList();
-			var arenaSecrets = standardSecrets.Where(x => !ArenaExcludes.Contains(x)).ToList();
+			var arenaSecrets = wildSecrets.Where(x => !ArenaExcludes.Contains(x)).ToList();
 			Assert.AreEqual(arenaSecrets.Count, cards.Count);
 			foreach(var secret in arenaSecrets)
 				Assert.IsNotNull(cards.SingleOrDefault(c => c.Id == secret));

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsManager.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsManager.cs
@@ -120,7 +120,8 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 				return card;
 			});
 
-			if(format == Format.Standard || gameMode == GameType.GT_ARENA)
+			//Temporarily remove Standard Secret filter for Wild Arena Fest Games
+			if(format == Format.Standard)
 				cards = cards.Where(c => !wildSets.Contains(c.Set));
 			if(gameMode == GameType.GT_ARENA)
 				cards = cards.Where(c => !CardIds.Secrets.ArenaExcludes.Contains(c.Id));


### PR DESCRIPTION
Removed the Standard filter for Arena secrets. This will need to be reverted when Wild Arena ends.

Resolves: Issue [#3569](https://github.com/HearthSim/Hearthstone-Deck-Tracker/issues/3569)