### PR TITLE
Use latest TLS for HDTUpdate

### DIFF
--- a/HDTUpdate/App.config
+++ b/HDTUpdate/App.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <runtime>
+      <AppContextSwitchOverrides value="Switch.System.Net.DontEnableSchUseStrongCrypto=false"/>
+    </runtime>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>


### PR DESCRIPTION
Fixes #3587

See https://stackoverflow.com/questions/44751179/tls-1-2-not-negotiated-in-net-4-7-without-explicit-servicepointmanager-security