### PR TITLE
Bootstrap: Provide error output for users without nuget or git

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,9 +1,23 @@
 @echo off
+set nuget_location=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
 
-nuget restore
-git clone https://github.com/HearthSim/HearthDb HearthDb
+:startup
+nuget restore || goto :nugetmissing
+git clone https://github.com/HearthSim/HearthDb HearthDb || goto :gitmissing
 git clone https://github.com/HearthSim/HearthMirror HearthMirror
 git clone https://github.com/HearthSim/HSReplay-API-Client.git HSReplay-Api
 git clone https://github.com/HearthSim/HDT-Localization HDT-Localization
 xcopy /Y "HDT-Localization\*.resx" "Hearthstone Deck Tracker\Properties\"
 ./generate_resources.bat
+goto :EOF
+
+:nugetmissing
+echo Nuget was not found and is required to run bootstrap.bat. Download and retry now?
+choice /c yn
+if %ERRORLEVEL%==2 goto :EOF
+powershell -Command "(New-Object Net.WebClient).DownloadFile('%nuget_location%', 'nuget.exe')"
+goto :startup
+
+:gitmissing
+echo Git was not found and is required to run bootstrap.bat. Download git from https://git-scm.com/download and during installation choose "Use Git from the Windows Command Prompt".
+pause


### PR DESCRIPTION
Provides some output for new contributors who don't have nuget or git installed (or in path). It will attempt to download the latest recommended nuget if the user requests it, but git cannot operate without files it depends on so it must be installed by the user.

Tested the nuget download script and it works even on Windows 7 without updates as Powershell 2.0 is pre-installed.

<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
