### PR TITLE
refresh comboboxes in option when language changes

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
@@ -63,15 +63,17 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void refreshComboBox(ComboBox comboBox)
 		{
+			_initialized = false;
 			int selectedIndex = comboBox.SelectedIndex;
 			comboBox.SelectedIndex = -1;
-			comboBox.Items.Refresh();
+			comboBox.Items.Refresh();	
 			comboBox.SelectedIndex = selectedIndex;
+			_initialized = true;
 		}
 
 		private void ComboboxAccent_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized || ComboboxAccent.SelectedItem == null)
+			if(!_initialized)
 				return;
 			var accent = ComboboxAccent.SelectedItem as Accent;
 			Config.Instance.AccentName = accent.Name;
@@ -81,7 +83,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboboxTheme_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized || ComboboxTheme.SelectedItem == null)
+			if(!_initialized)
 				return;
 			Config.Instance.AppTheme = (MetroTheme)ComboboxTheme.SelectedItem;
 			Config.Save();
@@ -91,7 +93,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboboxIconSet_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized || ComboBoxIconSet.SelectedItem == null || Config.Instance.ClassIconStyle == (IconStyle)ComboBoxIconSet.SelectedItem)
+			if(!_initialized)
 				return;
 			Config.Instance.ClassIconStyle = (IconStyle)ComboBoxIconSet.SelectedItem;
 			Config.Save();
@@ -100,7 +102,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboBoxCardTheme_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized || ComboBoxCardTheme.SelectedItem == null)
+			if(!_initialized)
 				return;
 			Config.Instance.CardBarTheme = ComboBoxCardTheme.SelectedItem.ToString().ToLowerInvariant();
 			if (Config.Instance.CardBarTheme != null)
@@ -112,7 +114,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboboxDeckLayout_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized || ComboBoxDeckLayout.SelectedItem == null || Config.Instance.DeckPickerItemLayout == (DeckLayout)ComboBoxDeckLayout.SelectedItem)
+			if(!_initialized)
 				return;
 			Config.Instance.DeckPickerItemLayout = (DeckLayout)ComboBoxDeckLayout.SelectedItem;
 			Config.Save();
@@ -140,7 +142,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboBoxClassColors_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized || ComboBoxClassColors.SelectedItem == null)
+			if(!_initialized)
 				return;
 			Config.Instance.ClassColorScheme = (ClassColorScheme)ComboBoxClassColors.SelectedItem;
 			Config.Save();
@@ -202,7 +204,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboBoxLanguage_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized || ComboBoxLanguage.SelectedItem == null)
+			if(!_initialized)
 				return;
 			Config.Instance.Localization = (Language)ComboBoxLanguage.SelectedItem;
 			Config.Save();

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
@@ -76,9 +76,12 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			if(!_initialized)
 				return;
 			var accent = ComboboxAccent.SelectedItem as Accent;
-			Config.Instance.AccentName = accent.Name;
-			Config.Save();
-			UITheme.UpdateAccent();
+			if (accent != null)
+			{
+				Config.Instance.AccentName = accent.Name;
+				Config.Save();
+				UITheme.UpdateAccent();
+			}
 		}
 
 		private void ComboboxTheme_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -105,11 +108,8 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			if(!_initialized)
 				return;
 			Config.Instance.CardBarTheme = ComboBoxCardTheme.SelectedItem.ToString().ToLowerInvariant();
-			if (Config.Instance.CardBarTheme != null)
-			{
-				Config.Save();
-				Utility.Themes.ThemeManager.SetTheme(Config.Instance.CardBarTheme);
-			}
+			Config.Save();
+			Utility.Themes.ThemeManager.SetTheme(Config.Instance.CardBarTheme);
 		}
 
 		private void ComboboxDeckLayout_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
@@ -51,22 +51,38 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			_initialized = true;
 		}
 
+		private void ReloadAfterChangeLanguage()
+		{
+			Load();
+			refreshComboBox(ComboboxTheme);
+			refreshComboBox(ComboboxAccent);
+			refreshComboBox(ComboBoxIconSet);
+			refreshComboBox(ComboBoxDeckLayout);
+			refreshComboBox(ComboBoxClassColors);
+			refreshComboBox(ComboBoxCardTheme);
+		}
+
+		private void refreshComboBox(ComboBox comboBox)
+		{
+			int selectedIndex = comboBox.SelectedIndex;
+			comboBox.SelectedIndex = -1;
+			comboBox.Items.Refresh();
+			comboBox.SelectedIndex = selectedIndex;
+		}
+
 		private void ComboboxAccent_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized)
+			if(!_initialized || ComboboxAccent.SelectedItem == null)
 				return;
 			var accent = ComboboxAccent.SelectedItem as Accent;
-			if(accent != null)
-			{
-				Config.Instance.AccentName = accent.Name;
-				Config.Save();
-				UITheme.UpdateAccent();
-			}
+			Config.Instance.AccentName = accent.Name;
+			Config.Save();
+			UITheme.UpdateAccent();
 		}
 
 		private void ComboboxTheme_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized)
+			if(!_initialized || ComboboxTheme.SelectedItem == null)
 				return;
 			Config.Instance.AppTheme = (MetroTheme)ComboboxTheme.SelectedItem;
 			Config.Save();
@@ -76,7 +92,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboboxIconSet_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized)
+			if(!_initialized || ComboBoxIconSet.SelectedItem == null || Config.Instance.ClassIconStyle == (IconStyle)ComboBoxIconSet.SelectedItem)
 				return;
 			Config.Instance.ClassIconStyle = (IconStyle)ComboBoxIconSet.SelectedItem;
 			Config.Save();
@@ -85,16 +101,19 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboBoxCardTheme_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized)
+			if(!_initialized || ComboBoxCardTheme.SelectedItem == null)
 				return;
 			Config.Instance.CardBarTheme = ComboBoxCardTheme.SelectedItem.ToString().ToLowerInvariant();
-			Config.Save();
-			Utility.Themes.ThemeManager.SetTheme(Config.Instance.CardBarTheme);
+			if (Config.Instance.CardBarTheme != null)
+			{
+				Config.Save();
+				Utility.Themes.ThemeManager.SetTheme(Config.Instance.CardBarTheme);
+			}
 		}
 
 		private void ComboboxDeckLayout_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized)
+			if(!_initialized || ComboBoxDeckLayout.SelectedItem == null || Config.Instance.DeckPickerItemLayout == (DeckLayout)ComboBoxDeckLayout.SelectedItem)
 				return;
 			Config.Instance.DeckPickerItemLayout = (DeckLayout)ComboBoxDeckLayout.SelectedItem;
 			Config.Save();
@@ -122,7 +141,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboBoxClassColors_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized)
+			if(!_initialized || ComboBoxClassColors.SelectedItem == null)
 				return;
 			Config.Instance.ClassColorScheme = (ClassColorScheme)ComboBoxClassColors.SelectedItem;
 			Config.Save();
@@ -184,12 +203,13 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboBoxLanguage_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized)
+			if(!_initialized || ComboBoxLanguage.SelectedItem == null)
 				return;
 			Config.Instance.Localization = (Language)ComboBoxLanguage.SelectedItem;
 			Config.Save();
 			LocUtil.UpdateCultureInfo();
 			UpdateUIAfterChangeLanguage();
+			ReloadAfterChangeLanguage();
 		}
 
 		private void UpdateUIAfterChangeLanguage()

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
@@ -51,9 +51,8 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			_initialized = true;
 		}
 
-		private void ReloadAfterChangeLanguage()
+		private void RefreshComboboxesAfterChangeLanguage()
 		{
-			Load();
 			refreshComboBox(ComboboxTheme);
 			refreshComboBox(ComboboxAccent);
 			refreshComboBox(ComboBoxIconSet);
@@ -209,7 +208,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			Config.Save();
 			LocUtil.UpdateCultureInfo();
 			UpdateUIAfterChangeLanguage();
-			ReloadAfterChangeLanguage();
+			RefreshComboboxesAfterChangeLanguage();
 		}
 
 		private void UpdateUIAfterChangeLanguage()

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
@@ -53,22 +53,22 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void RefreshComboboxesAfterChangeLanguage()
 		{
+			_initialized = false;
 			refreshComboBox(ComboboxTheme);
 			refreshComboBox(ComboboxAccent);
 			refreshComboBox(ComboBoxIconSet);
 			refreshComboBox(ComboBoxDeckLayout);
 			refreshComboBox(ComboBoxClassColors);
 			refreshComboBox(ComboBoxCardTheme);
+			_initialized = true;
 		}
 
 		private void refreshComboBox(ComboBox comboBox)
 		{
-			_initialized = false;
 			int selectedIndex = comboBox.SelectedIndex;
 			comboBox.SelectedIndex = -1;
 			comboBox.Items.Refresh();	
 			comboBox.SelectedIndex = selectedIndex;
-			_initialized = true;
 		}
 
 		private void ComboboxAccent_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

In last version,
if I changed language in option, items of comboboxes were not applied that change.
so I corrected it by refreshing comboboxes.

I fixed some code simply by using variable '_initialized'