### PR TITLE
Add setting to allow closing to tray

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -249,6 +249,9 @@ namespace Hearthstone_Deck_Tracker
 		public bool ClearLogFileAfterGame = true;
 
 		[DefaultValue(false)]
+		public bool CloseToTray = false;
+
+		[DefaultValue(false)]
 		public bool CloseWithHearthstone = false;
 
 		[DefaultValue(false)]

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml
@@ -40,6 +40,10 @@
                   HorizontalAlignment="Left" Margin="10,5,0,0"
                   VerticalAlignment="Top" Checked="CheckboxStartMinimized_Checked"
                   Unchecked="CheckboxStartMinimized_Unchecked" />
+        <CheckBox x:Name="CheckboxCloseTray" Content="{lex:Loc Options_Tracker_Settings_CheckBox_CloseToTray}"
+                  HorizontalAlignment="Left" Margin="10,5,0,0"
+                  VerticalAlignment="Top" Checked="CheckboxCloseTray_Checked"
+                  Unchecked="CheckboxCloseTray_Unchecked" />
         <CheckBox x:Name="CheckboxMinimizeTray" Content="{lex:Loc Options_Tracker_Settings_CheckBox_MinimizeToTray}"
                   HorizontalAlignment="Left" Margin="10,5,0,0"
                   VerticalAlignment="Top" Checked="CheckboxMinimizeTray_Checked"

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml.cs
@@ -35,6 +35,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		public void Load()
 		{
+			CheckboxCloseTray.IsChecked = Config.Instance.CloseToTray;
 			CheckboxMinimizeTray.IsChecked = Config.Instance.MinimizeToTray;
 			CheckboxStartMinimized.IsChecked = Config.Instance.StartMinimized;
 			CheckboxCheckForUpdates.IsChecked = Config.Instance.CheckForUpdates;
@@ -86,6 +87,22 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			if(!_initialized)
 				return;
 			Config.Instance.MinimizeToTray = false;
+			SaveConfig(false);
+		}
+
+		private void CheckboxCloseTray_Checked(object sender, RoutedEventArgs e)
+		{
+			if (!_initialized)
+				return;
+			Config.Instance.CloseToTray = true;
+			SaveConfig(false);
+		}
+
+		private void CheckboxCloseTray_Unchecked(object sender, RoutedEventArgs e)
+		{
+			if (!_initialized)
+				return;
+			Config.Instance.CloseToTray = false;
 			SaveConfig(false);
 		}
 

--- a/Hearthstone Deck Tracker/TrayIcon.cs
+++ b/Hearthstone Deck Tracker/TrayIcon.cs
@@ -59,7 +59,11 @@ namespace Hearthstone_Deck_Tracker
 			MenuItemShow = new MenuItem(LocUtil.Get("TrayIcon_MenuItemShow"), (sender, args) => Core.MainWindow.ActivateWindow());
 			NotifyIcon.ContextMenu.MenuItems.Add(MenuItemShow);
 
-			MenuItemExit = new MenuItem(LocUtil.Get("TrayIcon_MenuItemExit"), (sender, args) => Core.MainWindow.Close());
+			MenuItemExit = new MenuItem(LocUtil.Get("TrayIcon_MenuItemExit"), (sender, args) =>
+			{
+				Core.MainWindow.ExitRequestedFromTray = true;
+				Core.MainWindow.Close();
+			});
 			NotifyIcon.ContextMenu.MenuItems.Add(MenuItemExit);
 
 			NotifyIcon.MouseClick += (sender, args) =>

--- a/Hearthstone Deck Tracker/Windows/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/MainWindow.xaml.cs
@@ -159,6 +159,7 @@ namespace Hearthstone_Deck_Tracker.Windows
 #region Properties
 
 		private bool _initialized => Core.Initialized;
+		public bool ExitRequestedFromTray;
 
 		private double _heightChangeDueToSearchBox;
 		public const int SearchBoxHeight = 30;
@@ -294,6 +295,14 @@ namespace Hearthstone_Deck_Tracker.Windows
 
 		private async void Window_Closing(object sender, CancelEventArgs e)
 		{
+
+			if (!ExitRequestedFromTray && Config.Instance.CloseToTray)
+			{
+				MinimizeToTray();
+				e.Cancel = true;
+				return;
+			}
+
 			try
 			{
 				Log.Info("Shutting down...");


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [X] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [X] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->


I often hit close but what I really wanted was just to close the window, not to terminate the application. Add a setting that when the close button is hit it will instead minimize. 

I added a public variable to the form that the tray icon can set, I thought this might be better then adding an entire new function.

Unsure about how to handle the localization of Options_Tracker_Settings_CheckBox_CloseToTray




