### PR TITLE
Refresh Overlay Player & Opponent's panel and combo box

### DIFF
--- a/Hearthstone Deck Tracker/Controls/ElementSorter.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/ElementSorter.xaml.cs
@@ -21,6 +21,8 @@ namespace Hearthstone_Deck_Tracker
 
 		public void AddItem(ElementSorterItem item) => StackPanel.Children.Add(item);
 
+		public void Clear() => StackPanel.Children.Clear();
+
 		public void MoveItem(ElementSorterItem item, SortDirection direction)
 		{
 			var index = StackPanel.Children.IndexOf(item) + (direction == SortDirection.Up ? -1 : 1);

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayOpponent.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayOpponent.xaml
@@ -7,6 +7,7 @@
              xmlns:overlay="clr-namespace:Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay"
              xmlns:options="clr-namespace:Hearthstone_Deck_Tracker.FlyoutControls.Options"
              xmlns:lex="http://wpflocalizeextension.codeplex.com"
+             xmlns:utility="clr-namespace:Hearthstone_Deck_Tracker.Utility"
              lex:LocalizeDictionary.DesignCulture="en"
              lex:ResxLocalizationProvider.DefaultAssembly="HearthstoneDeckTracker"
              lex:ResxLocalizationProvider.DefaultDictionary="Strings"
@@ -66,7 +67,7 @@
             <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Cthun}" />
             <ComboBox x:Name="ComboBoxCthun" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
-                      SelectionChanged="ComboBoxCthun_SelectionChanged">
+                      utility:ComboBoxHelper.SelectionChanged="ComboBoxCthun_SelectionChanged">
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
@@ -78,7 +79,7 @@
             <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Yogg}" />
             <ComboBox x:Name="ComboBoxSpells" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
-                      SelectionChanged="ComboBoxSpells_SelectionChanged">
+                      utility:ComboBoxHelper.SelectionChanged="ComboBoxSpells_SelectionChanged">
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
@@ -90,7 +91,7 @@
             <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Jade}" />
             <ComboBox x:Name="ComboBoxJade" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
-                      SelectionChanged="ComboBoxJade_SelectionChanged">
+                      utility:ComboBoxHelper.SelectionChanged="ComboBoxJade_SelectionChanged">
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayOpponent.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayOpponent.xaml.cs
@@ -102,9 +102,9 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 
 		private void SetPanel()
 		{
-			foreach (var panel in Config.Instance.DeckPanelOrderOpponent)
+			foreach(var panel in Config.Instance.DeckPanelOrderOpponent)
 			{
-				switch (panel)
+				switch(panel)
 				{
 					case Enums.DeckPanel.Winrate:
 						ElementSorterOpponent.AddItem(new ElementSorterItem(panel, Config.Instance.ShowWinRateAgainst,

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayOpponent.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayOpponent.xaml.cs
@@ -93,9 +93,18 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 			CheckboxHideSecrets.IsChecked = Config.Instance.HideSecrets;
 
 			ElementSorterOpponent.IsPlayer = false;
-			foreach(var panel in Config.Instance.DeckPanelOrderOpponent)
+			SetPanel();
+
+			Core.Overlay.UpdateOpponentLayout();
+			Core.Windows.OpponentWindow.UpdateOpponentLayout();
+			_initialized = true;
+		}
+
+		private void SetPanel()
+		{
+			foreach (var panel in Config.Instance.DeckPanelOrderOpponent)
 			{
-				switch(panel)
+				switch (panel)
 				{
 					case Enums.DeckPanel.Winrate:
 						ElementSorterOpponent.AddItem(new ElementSorterItem(panel, Config.Instance.ShowWinRateAgainst,
@@ -119,9 +128,12 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 						break;
 				}
 			}
-			Core.Overlay.UpdateOpponentLayout();
-			Core.Windows.OpponentWindow.UpdateOpponentLayout();
-			_initialized = true;
+		}
+
+		public void ReloadUI()
+		{
+			ElementSorterOpponent.Clear();
+			SetPanel();
 		}
 
 		private void CheckboxHighlightDiscarded_Checked(object sender, RoutedEventArgs e)

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayPlayer.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayPlayer.xaml
@@ -7,6 +7,7 @@
              xmlns:overlay="clr-namespace:Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay"
              xmlns:options="clr-namespace:Hearthstone_Deck_Tracker.FlyoutControls.Options"
              xmlns:lex="http://wpflocalizeextension.codeplex.com"
+             xmlns:utility="clr-namespace:Hearthstone_Deck_Tracker.Utility"
              lex:LocalizeDictionary.DesignCulture="en"
              lex:ResxLocalizationProvider.DefaultAssembly="HearthstoneDeckTracker"
              lex:ResxLocalizationProvider.DefaultDictionary="Strings"
@@ -42,7 +43,7 @@
             <Label Content="{lex:LocText Options_Overlay_Player_Label_Cthun}" />
             <ComboBox x:Name="ComboBoxCthun" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
-                      SelectionChanged="ComboBoxCthun_SelectionChanged">
+                      utility:ComboBoxHelper.SelectionChanged="ComboBoxCthun_SelectionChanged">
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
@@ -54,7 +55,7 @@
             <Label Content="{lex:LocText Options_Overlay_Player_Label_Yogg}" />
             <ComboBox x:Name="ComboBoxSpells" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
-                      SelectionChanged="ComboBoxSpells_SelectionChanged">
+                      utility:ComboBoxHelper.SelectionChanged="ComboBoxSpells_SelectionChanged">
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
@@ -66,7 +67,7 @@
             <Label Content="{lex:LocText Options_Overlay_Player_Label_Jade}" />
             <ComboBox x:Name="ComboBoxJade" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
-                      SelectionChanged="ComboBoxJade_SelectionChanged">
+                      utility:ComboBoxHelper.SelectionChanged="ComboBoxJade_SelectionChanged">
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayPlayer.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayPlayer.xaml.cs
@@ -80,9 +80,9 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 
 		private void SetPanel()
 		{
-			foreach (var panel in Config.Instance.DeckPanelOrderPlayer)
+			foreach(var panel in Config.Instance.DeckPanelOrderPlayer)
 			{
-				switch (panel)
+				switch(panel)
 				{
 					case Enums.DeckPanel.Cards:
 						ElementSorterPlayer.AddItem(new ElementSorterItem(panel, !Config.Instance.HidePlayerCards,

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayPlayer.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayPlayer.xaml.cs
@@ -73,9 +73,16 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 			ComboBoxJade.SelectedItem = Config.Instance.PlayerJadeCounter;
 
 			ElementSorterPlayer.IsPlayer = true;
-			foreach(var panel in Config.Instance.DeckPanelOrderPlayer)
+			SetPanel();
+
+			_initialized = true;
+		}
+
+		private void SetPanel()
+		{
+			foreach (var panel in Config.Instance.DeckPanelOrderPlayer)
 			{
-				switch(panel)
+				switch (panel)
 				{
 					case Enums.DeckPanel.Cards:
 						ElementSorterPlayer.AddItem(new ElementSorterItem(panel, !Config.Instance.HidePlayerCards,
@@ -103,7 +110,12 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 						break;
 				}
 			}
-			_initialized = true;
+		}
+
+		public void ReloadUI()
+		{
+			ElementSorterPlayer.Clear();
+			SetPanel();
 		}
 
 		private void CheckboxHighlightCardsInHand_Checked(object sender, RoutedEventArgs e)

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
@@ -211,6 +211,10 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			// Deck Picker
 			Core.MainWindow.DeckPickerList.ReloadUI();
 
+			//Overlay Panel
+			Core.MainWindow.Options.OptionsOverlayPlayer.ReloadUI();
+			Core.MainWindow.Options.OptionsOverlayOpponent.ReloadUI();
+
 			// Reload ComboBoxes
 			ComboBoxHelper.Update();
 		}

--- a/Plugins/READ THIS.txt
+++ b/Plugins/READ THIS.txt
@@ -1,4 +1,0 @@
-PLUGINS INSTALLED TO THIS DIRECTORY WILL BE REMOVED!
-
-Please install your new plugins to '%AppData%/HearthstoneDeckTracker'.
-'options > tracker > plugins > plugins folder' will open that directory for you.

--- a/Plugins/READ THIS.txt
+++ b/Plugins/READ THIS.txt
@@ -1,0 +1,4 @@
+PLUGINS INSTALLED TO THIS DIRECTORY WILL BE REMOVED!
+
+Please install your new plugins to '%AppData%/HearthstoneDeckTracker'.
+'options > tracker > plugins > plugins folder' will open that directory for you.


### PR DESCRIPTION
When I changed the language setting, the overlay player and opponent's panel and combo box language did not change automatically.
I used the ComboBoxHelper to change the language of the combo box automatically.
And I add the ReloadUI function to the player and opponent to automatically change the panel's language.



<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [v] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [v] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
