### PR TITLE
Added tracking for several Monster Hunt cards

### DIFF
--- a/Hearthstone Deck Tracker/LogReader/Handlers/PowerHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/PowerHandler.cs
@@ -364,6 +364,24 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 							case NonCollectible.Neutral.SackOfCoins:
 								AddKnownCardId(gameState, NonCollectible.Neutral.HeftySackOfCoins);
 								break;
+							case NonCollectible.Neutral.CreepyCurio:
+								AddKnownCardId(gameState, NonCollectible.Neutral.HauntedCurio);
+								break;
+							case NonCollectible.Neutral.HauntedCurio:
+								AddKnownCardId(gameState, NonCollectible.Neutral.CursedCurio);
+								break;
+							case NonCollectible.Neutral.OldMilitiaHorn:
+								AddKnownCardId(gameState, NonCollectible.Neutral.MilitiaHorn);
+								break;
+							case NonCollectible.Neutral.MilitiaHorn:
+								AddKnownCardId(gameState, NonCollectible.Neutral.VeteransMilitiaHorn);
+								break;
+							case NonCollectible.Neutral.SurlyMob:
+								AddKnownCardId(gameState, NonCollectible.Neutral.AngryMob);
+								break;
+							case NonCollectible.Neutral.AngryMob:
+								AddKnownCardId(gameState, NonCollectible.Neutral.CrazedMob);
+								break;
 							//case Collectible.Rogue.Wanted: -- TODO
 							//	AddKnownCardId(gameState, NonCollectible.Neutral.TheCoin);
 							//	break;


### PR DESCRIPTION
Added tracking for the following cards:
- Creepy Curio
- Haunted Curio
- Old Militia Horn
- Militia Horn
- Surly Mob
- Angry Mob
