### PR TITLE
[Options] Only use ScrollViewer where needed

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsMain.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/OptionsMain.xaml
@@ -62,9 +62,7 @@
                     </Image>
                     <Separator Margin="-5,5" Background="{DynamicResource AccentColorBrush}"/>
                 </StackPanel>
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <ContentControl Content="{Binding OptionsContent}"/>
-                </ScrollViewer>
+                <ContentControl Content="{Binding OptionsContent}"/>
             </DockPanel>
         </GroupBox>
     </DockPanel>

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayOpponent.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayOpponent.xaml
@@ -13,8 +13,9 @@
              lex:ResxLocalizationProvider.DefaultDictionary="Strings"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="400">
-    <StackPanel>
-        <CheckBox x:Name="CheckboxSameScaling"
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <CheckBox x:Name="CheckboxSameScaling"
                   Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}"
                   Content="{lex:LocText Options_Overlay_Opponent_CheckBox_SameScaling}"
                   Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"
@@ -22,118 +23,119 @@
                   Margin="10,5,0,0" VerticalAlignment="Top" IsChecked="True"
                   Checked="CheckboxSameScaling_Checked"
                   Unchecked="CheckboxSameScaling_Unchecked" />
-        <DockPanel Margin="10,5,10,0">
-            <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Scaling}" />
-            <TextBox Name="TextBoxScaling" PreviewTextInput="TextBoxScaling_OnPreviewTextInput"
+            <DockPanel Margin="10,5,10,0">
+                <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Scaling}" />
+                <TextBox Name="TextBoxScaling" PreviewTextInput="TextBoxScaling_OnPreviewTextInput"
                      Text="{Binding OpponentScaling, RelativeSource={RelativeSource AncestorType=overlay:OverlayOpponent}}"
                      DockPanel.Dock="Right" Margin="5,0,0,0" Width="50" />
-            <Slider x:Name="SliderOverlayOpponentScaling" HorizontalAlignment="Right"
+                <Slider x:Name="SliderOverlayOpponentScaling" HorizontalAlignment="Right"
                     VerticalAlignment="Center" Width="150"
                     Value="{Binding OpponentScaling, RelativeSource={RelativeSource AncestorType=overlay:OverlayOpponent}, Delay=100}"
                     Minimum="1" SmallChange="1" LargeChange="10" Maximum="200" />
-        </DockPanel>
-        <DockPanel Margin="10,5,10,0"
+            </DockPanel>
+            <DockPanel Margin="10,5,10,0"
                    Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}">
-            <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Opacity}" HorizontalAlignment="Left"
+                <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Opacity}" HorizontalAlignment="Left"
                    Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"
                    VerticalAlignment="Top" />
-            <Slider x:Name="SliderOpponentOpacity" HorizontalAlignment="Right"
+                <Slider x:Name="SliderOpponentOpacity" HorizontalAlignment="Right"
                     VerticalAlignment="Center" Width="205" Value="100"
                     ValueChanged="SliderOpponentOpacity_ValueChanged" />
-        </DockPanel>
-        <DockPanel Margin="10,5,10,0"
+            </DockPanel>
+            <DockPanel Margin="10,5,10,0"
                    Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}">
-            <Label Content="{lex:LocText Options_Overlay_Opponent_Label_SecretScaling}"
+                <Label Content="{lex:LocText Options_Overlay_Opponent_Label_SecretScaling}"
                    Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}" />
-            <TextBox Name="TextBoxSecretScaling" PreviewTextInput="TextBoxScaling_OnPreviewTextInput"
+                <TextBox Name="TextBoxSecretScaling" PreviewTextInput="TextBoxScaling_OnPreviewTextInput"
                      Text="{Binding SecretScaling, RelativeSource={RelativeSource AncestorType=overlay:OverlayOpponent}}"
                      DockPanel.Dock="Right" Margin="5,0,0,0" Width="50" />
-            <Slider x:Name="SliderOverlaySecretScaling" HorizontalAlignment="Right"
+                <Slider x:Name="SliderOverlaySecretScaling" HorizontalAlignment="Right"
                     VerticalAlignment="Center" Width="150"
                     Value="{Binding SecretScaling, RelativeSource={RelativeSource AncestorType=overlay:OverlayOpponent}}"
                     Minimum="1" SmallChange="1" LargeChange="10" Maximum="200" />
-        </DockPanel>
-        <DockPanel Margin="10,5,10,0"
+            </DockPanel>
+            <DockPanel Margin="10,5,10,0"
                    Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}">
-            <Label Content="{lex:LocText Options_Overlay_Opponent_LabelSecretOpacity}"
+                <Label Content="{lex:LocText Options_Overlay_Opponent_LabelSecretOpacity}"
                    Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"
                    HorizontalAlignment="Left"
                    VerticalAlignment="Top" />
-            <Slider x:Name="SliderSecretOpacity" HorizontalAlignment="Right"
+                <Slider x:Name="SliderSecretOpacity" HorizontalAlignment="Right"
                     VerticalAlignment="Center" Width="205" Value="100"
                     ValueChanged="SliderSecretOpacity_ValueChanged" />
-        </DockPanel>
-        <DockPanel Margin="5,5,5,0">
-            <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Cthun}" />
-            <ComboBox x:Name="ComboBoxCthun" HorizontalAlignment="Right"
+            </DockPanel>
+            <DockPanel Margin="5,5,5,0">
+                <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Cthun}" />
+                <ComboBox x:Name="ComboBoxCthun" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
                       utility:ComboBoxHelper.SelectionChanged="ComboBoxCthun_SelectionChanged">
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
-        </DockPanel>
-        <DockPanel Margin="5,5,5,0">
-            <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Yogg}" />
-            <ComboBox x:Name="ComboBoxSpells" HorizontalAlignment="Right"
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </DockPanel>
+            <DockPanel Margin="5,5,5,0">
+                <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Yogg}" />
+                <ComboBox x:Name="ComboBoxSpells" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
                       utility:ComboBoxHelper.SelectionChanged="ComboBoxSpells_SelectionChanged">
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
-        </DockPanel>
-        <DockPanel Margin="5,5,5,0">
-            <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Jade}" />
-            <ComboBox x:Name="ComboBoxJade" HorizontalAlignment="Right"
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </DockPanel>
+            <DockPanel Margin="5,5,5,0">
+                <Label Content="{lex:LocText Options_Overlay_Opponent_Label_Jade}" />
+                <ComboBox x:Name="ComboBoxJade" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
                       utility:ComboBoxHelper.SelectionChanged="ComboBoxJade_SelectionChanged">
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
-        </DockPanel>
-        <CheckBox x:Name="CheckboxHideOpponentCardAge" Content="{lex:Loc Options_Overlay_General_CheckBox_HideCardAge}"
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </DockPanel>
+            <CheckBox x:Name="CheckboxHideOpponentCardAge" Content="{lex:Loc Options_Overlay_General_CheckBox_HideCardAge}"
                   HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckboxHideOpponentCardAge_Checked"
                   Unchecked="CheckboxHideOpponentCardAge_Unchecked" />
-        <CheckBox x:Name="CheckboxHideOpponentCardMarks" Content="{lex:Loc Options_Overlay_General_CheckBox_HideCardMarks}"
+            <CheckBox x:Name="CheckboxHideOpponentCardMarks" Content="{lex:Loc Options_Overlay_General_CheckBox_HideCardMarks}"
                   Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckboxHideOpponentCardMarks_Checked"
                   Unchecked="CheckboxHideOpponentCardMarks_Unchecked"
                   HorizontalAlignment="Left" />
-        <CheckBox x:Name="CheckboxHideSecrets" Content="{lex:Loc Options_Overlay_General_CheckBox_HideSecrets}"
+            <CheckBox x:Name="CheckboxHideSecrets" Content="{lex:Loc Options_Overlay_General_CheckBox_HideSecrets}"
                   HorizontalAlignment="Left"
                   VerticalAlignment="Top" Checked="CheckboxHideSecrets_Checked"
                   Unchecked="CheckboxHideSecrets_Unchecked" Margin="10,5,0,0" />
-        <CheckBox x:Name="CheckBoxAttack"
+            <CheckBox x:Name="CheckBoxAttack"
                   Content="{lex:LocText Options_Overlay_Opponent_CheckBox_Attack}" HorizontalAlignment="Left"
                   Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckBoxAttack_Checked"
                   Unchecked="CheckBoxAttack_Unchecked" />
-        <CheckBox x:Name="CheckBoxCenterDeckVertically"
+            <CheckBox x:Name="CheckBoxCenterDeckVertically"
                   Content="{lex:LocText Options_Overlay_Opponent_CheckBox_CenterVertically}" HorizontalAlignment="Left"
                   ToolTip="{lex:Loc Options_Overlay_Opponent_CheckBox_CenterVertically_Tooltip}"
                   Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckBoxCenterDeckVertically_Checked"
                   Unchecked="CheckBoxCenterDeckVertically_Unchecked" />
-        <CheckBox x:Name="CheckboxIncludeCreated"
+            <CheckBox x:Name="CheckboxIncludeCreated"
                   Content="{lex:LocText Options_Overlay_Opponent_CheckBox_CreatedCards}" HorizontalAlignment="Left"
                   Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckboxIncludeCreated_Checked"
                   Unchecked="CheckboxIncludeCreated_Unchecked" />
-        <CheckBox x:Name="CheckboxHighlightDiscarded"
+            <CheckBox x:Name="CheckboxHighlightDiscarded"
                   Content="{lex:LocText Options_Overlay_Opponent_CheckBox_DiscardedCards}" HorizontalAlignment="Left"
                   Margin="10,5,0,10" VerticalAlignment="Top"
                   Checked="CheckboxHighlightDiscarded_Checked"
                   Unchecked="CheckboxHighlightDiscarded_Unchecked" />
-        <hearthstoneDeckTracker:ElementSorter x:Name="ElementSorterOpponent" Margin="10,5,10,10"
+            <hearthstoneDeckTracker:ElementSorter x:Name="ElementSorterOpponent" Margin="10,5,10,10"
                                               Height="auto" />
-    </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
 </UserControl>

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayPlayer.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayPlayer.xaml
@@ -13,98 +13,100 @@
              lex:ResxLocalizationProvider.DefaultDictionary="Strings"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="300">
-    <StackPanel>
-        <CheckBox x:Name="CheckboxSameScaling"
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <CheckBox x:Name="CheckboxSameScaling"
                   Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"
                   Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}"
                   Content="{lex:LocText Options_Overlay_Player_CheckBox_SameScaling}" HorizontalAlignment="Left"
                   Margin="10,5,0,0" VerticalAlignment="Top" IsChecked="True"
                   Checked="CheckboxSameScaling_Checked"
                   Unchecked="CheckboxSameScaling_Unchecked" />
-        <DockPanel Margin="10,5,10,0">
-            <Label Content="{lex:LocText Options_Overlay_Player_Label_Scaling}" />
-            <TextBox Name="TextBoxScaling" PreviewTextInput="TextBoxScaling_OnPreviewTextInput"
+            <DockPanel Margin="10,5,10,0">
+                <Label Content="{lex:LocText Options_Overlay_Player_Label_Scaling}" />
+                <TextBox Name="TextBoxScaling" PreviewTextInput="TextBoxScaling_OnPreviewTextInput"
                      Text="{Binding PlayerScaling, RelativeSource={RelativeSource AncestorType=overlay:OverlayPlayer}}"
                      DockPanel.Dock="Right" Margin="5,0,0,0" Width="50" />
-            <Slider x:Name="SliderOverlayPlayerScaling" HorizontalAlignment="Right"
+                <Slider x:Name="SliderOverlayPlayerScaling" HorizontalAlignment="Right"
                     VerticalAlignment="Center" Width="150"
                     Value="{Binding PlayerScaling, RelativeSource={RelativeSource AncestorType=overlay:OverlayPlayer}, Delay=100}"
                     Minimum="1" SmallChange="1" LargeChange="10" Maximum="200" />
-        </DockPanel>
-        <DockPanel Margin="10,5,10,0"
+            </DockPanel>
+            <DockPanel Margin="10,5,10,0"
                    Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}">
-            <Label Content="{lex:LocText Options_Overlay_Player_Label_Opacity}"
+                <Label Content="{lex:LocText Options_Overlay_Player_Label_Opacity}"
                    Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}" />
-            <Slider x:Name="SliderPlayerOpacity" HorizontalAlignment="Right"
+                <Slider x:Name="SliderPlayerOpacity" HorizontalAlignment="Right"
                     VerticalAlignment="Center" Width="205" Value="100"
                     ValueChanged="SliderPlayerOpacity_ValueChanged" SmallChange="1" LargeChange="10" />
-        </DockPanel>
-        <DockPanel Margin="5,5,5,0">
-            <Label Content="{lex:LocText Options_Overlay_Player_Label_Cthun}" />
-            <ComboBox x:Name="ComboBoxCthun" HorizontalAlignment="Right"
+            </DockPanel>
+            <DockPanel Margin="5,5,5,0">
+                <Label Content="{lex:LocText Options_Overlay_Player_Label_Cthun}" />
+                <ComboBox x:Name="ComboBoxCthun" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
                       utility:ComboBoxHelper.SelectionChanged="ComboBoxCthun_SelectionChanged">
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
-        </DockPanel>
-        <DockPanel Margin="5,5,5,0">
-            <Label Content="{lex:LocText Options_Overlay_Player_Label_Yogg}" />
-            <ComboBox x:Name="ComboBoxSpells" HorizontalAlignment="Right"
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </DockPanel>
+            <DockPanel Margin="5,5,5,0">
+                <Label Content="{lex:LocText Options_Overlay_Player_Label_Yogg}" />
+                <ComboBox x:Name="ComboBoxSpells" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
                       utility:ComboBoxHelper.SelectionChanged="ComboBoxSpells_SelectionChanged">
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
-        </DockPanel>
-        <DockPanel Margin="5,5,5,0">
-            <Label Content="{lex:LocText Options_Overlay_Player_Label_Jade}" />
-            <ComboBox x:Name="ComboBoxJade" HorizontalAlignment="Right"
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </DockPanel>
+            <DockPanel Margin="5,5,5,0">
+                <Label Content="{lex:LocText Options_Overlay_Player_Label_Jade}" />
+                <ComboBox x:Name="ComboBoxJade" HorizontalAlignment="Right"
                       Margin="5,0,0,0" VerticalAlignment="Top" Width="150"
                       utility:ComboBoxHelper.SelectionChanged="ComboBoxJade_SelectionChanged">
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
-        </DockPanel>
-        <CheckBox x:Name="CheckBoxAttack"
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </DockPanel>
+            <CheckBox x:Name="CheckBoxAttack"
                   Content="{lex:LocText Options_Overlay_Player_CheckBox_Attack}" HorizontalAlignment="Left"
                   Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckBoxAttack_Checked"
                   Unchecked="CheckBoxAttack_Unchecked" />
-        <CheckBox x:Name="CheckBoxCenterDeckVertically"
+            <CheckBox x:Name="CheckBoxCenterDeckVertically"
                   Content="{lex:LocText Options_Overlay_Player_CheckBox_CenterVertically}" HorizontalAlignment="Left"
                   ToolTip="{lex:LocText Options_Overlay_Player_CheckBox_CenterVertically_Tooltip}"
                   Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckBoxCenterDeckVertically_Checked"
                   Unchecked="CheckBoxCenterDeckVertically_Unchecked" />
-        <CheckBox x:Name="CheckboxHighlightCardsInHand"
+            <CheckBox x:Name="CheckboxHighlightCardsInHand"
                   Content="{lex:LocText Options_Overlay_Player_CheckBox_HighlightHand}" HorizontalAlignment="Left"
                   Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckboxHighlightCardsInHand_Checked"
                   Unchecked="CheckboxHighlightCardsInHand_Unchecked" />
-        <CheckBox x:Name="CheckboxHighlightLastDrawn"
+            <CheckBox x:Name="CheckboxHighlightLastDrawn"
                   Content="{lex:LocText Options_Overlay_Player_CheckBox_HighlightDrawn}" HorizontalAlignment="Left"
                   Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckboxHighlightLastDrawn_Checked"
                   Unchecked="CheckboxHighlightLastDrawn_Unchecked" />
-        <CheckBox x:Name="CheckboxRemoveCards" Content="{lex:LocText Options_Overlay_Player_CheckBox_RemoveZero}"
+            <CheckBox x:Name="CheckboxRemoveCards" Content="{lex:LocText Options_Overlay_Player_CheckBox_RemoveZero}"
                   HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckboxRemoveCards_Checked"
                   Unchecked="CheckboxRemoveCards_Unchecked" />
-        <CheckBox x:Name="CheckboxShowPlayerGet" Content="{lex:LocText Options_Overlay_Player_CheckBox_IncludeCreated}"
+            <CheckBox x:Name="CheckboxShowPlayerGet" Content="{lex:LocText Options_Overlay_Player_CheckBox_IncludeCreated}"
                   HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top"
                   Checked="CheckboxShowPlayerGet_Checked"
                   Unchecked="CheckboxShowPlayerGet_Unchecked" />
-        <hearthstoneDeckTracker:ElementSorter x:Name="ElementSorterPlayer" Margin="10,5,10,10"
+            <hearthstoneDeckTracker:ElementSorter x:Name="ElementSorterPlayer" Margin="10,5,10,10"
                                               Height="auto" />
-    </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [X] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [X] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

The buttons at the bottom of Options/Tracker/Plugins are hidden if the user has multiple plugins installed. Can be confusing and annoying, so I only added a ScrollViewer control where it's actually needed.