### PR TITLE
Add tooltips for Kalimos Invocation cards

### DIFF
--- a/HDTTests/Hearthstone/CardDbTest.cs
+++ b/HDTTests/Hearthstone/CardDbTest.cs
@@ -87,5 +87,18 @@ namespace HDTTests.Hearthstone
 			var name = Database.GetHeroNameFromId(CardIds.NonCollectible.Warlock.XolTheUnscathedHeroic);
 			Assert.AreEqual("Xol the Unscathed", name);
 		}
+
+		[TestMethod]
+		public void TestEntourageCards()
+		{
+			var lichKing = Database.GetCardFromName("The Lich King");
+			Assert.AreEqual(8, lichKing.EntourageCardIds.Length);
+
+			var angryChicken = Database.GetCardFromName("Angry Chicken");
+			Assert.AreEqual(0, angryChicken.EntourageCardIds.Length);
+
+			var kalimos = Database.GetCardFromName("Kalimos, Primal Lord");
+			Assert.AreEqual(4, kalimos.EntourageCardIds.Length);
+		}
 	}
 }

--- a/Hearthstone Deck Tracker/Hearthstone/Card.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Card.cs
@@ -302,7 +302,18 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			set { _localizedName = value; }
 		}
 
-		public string[] EntourageCardIds => _dbCard != null ? _dbCard.EntourageCardIds : new string[0];
+		public string[] EntourageCardIds
+		{
+			get
+			{
+				var entourageIds = _dbCard?.EntourageCardIds ?? new string[0];
+
+				return (CardIds.EntourageAdditionalCardIds.TryGetValue(_dbCard.Id, out string[] additionalIds)) ?
+					entourageIds.Union(additionalIds).ToArray() :
+					entourageIds;
+			}
+		}
+
 
 		[XmlIgnore]
 		public int InHandCount

--- a/Hearthstone Deck Tracker/Hearthstone/CardIds.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/CardIds.cs
@@ -72,6 +72,20 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			{"Priest", Collectible.Priest.AnduinWrynn}
 		};
 
+		// cards that should have an entourage list but don't in the game data
+		public static readonly Dictionary<string, string[]> EntourageAdditionalCardIds = new Dictionary<string, string[]>
+		{
+			{Collectible.Shaman.KalimosPrimalLord,
+				new string[]
+				{
+					NonCollectible.Shaman.KalimosPrimalLord_InvocationOfAir,
+					NonCollectible.Shaman.KalimosPrimalLord_InvocationOfEarth,
+					NonCollectible.Shaman.KalimosPrimalLord_InvocationOfFire,
+					NonCollectible.Shaman.KalimosPrimalLord_InvocationOfWater
+				}
+			}
+		};
+
 		public static class Secrets
 		{
 			public static List<string> ArenaExcludes = new List<string>


### PR DESCRIPTION
Adds feature for #3717 
Added these entourage cards for Kalimos in the most general and reusable way I could think of. Followed the example of some existing hard-coded dictionaries. 
This dictionary can be added to easily in the future, and will union any additional cards in with the list from the db. 
I also added a unit test to prove entourage cards from the db still work too. 

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
