### PR TITLE
Fix attempt on checked secrets

### DIFF
--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
@@ -109,17 +109,20 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 				HandleAttack(attacker, defender, true);
 		}
 
-		public void HandleMinionPlayed()
+		public void HandleMinionPlayed(Entity entity)
 		{
+			_targetedEntity = entity;
 			if(!HandleAction)
 				return;
-
+			
 			var exclude = new List<string>();
-
+			if(_targetedEntity != null)
+			{
+				exclude.Add(Mage.PotionOfPolymorph);
+				exclude.Add(Paladin.Repentance);
+			}
 			exclude.Add(Hunter.Snipe);
 			exclude.Add(Mage.ExplosiveRunes);
-			exclude.Add(Mage.PotionOfPolymorph);
-			exclude.Add(Paladin.Repentance);
 
 			if(FreeSpaceOnBoard)
 				exclude.Add(Mage.MirrorEntity);


### PR DESCRIPTION
Attempt to fix the bug where when explosive runes triggers and kills the minion on play, potion of polymorph marked as "checked" as well. 
At the file Hearthstone-Deck-Tracker/Hearthstone Deck Tracker/GameEventHandler.cs,
line 213 i added the entity parameters to be passed to HandleMinionPlayed


<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [ O] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [ O] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
