### PR TITLE
Fix incorrect secret handling

### DIFF
--- a/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
+++ b/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
@@ -237,7 +237,7 @@ namespace HDTTests.Hearthstone.Secrets
 		[TestMethod]
 		public void SingleSecret_MinionPlayed()
 		{
-			_gameEventHandler.HandlePlayerMinionPlayed();
+			_gameEventHandler.HandlePlayerMinionPlayed(_playerMinion1);
 			VerifySecrets(0, HunterSecrets.All, HunterSecrets.Snipe);
 			VerifySecrets(1, MageSecrets.All, MageSecrets.ExplosiveRunes, MageSecrets.MirrorEntity, MageSecrets.PotionOfPolymorph, MageSecrets.FrozenClone);
 			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.Repentance);
@@ -334,7 +334,7 @@ namespace HDTTests.Hearthstone.Secrets
 		[TestMethod]
 		public void SingleSecret_PlayerPlaysMinion_OpponentPlaysMinion()
 		{
-			_game.SecretsManager.HandleMinionPlayed();
+			_game.SecretsManager.HandleMinionPlayed(_playerMinion1);
 			_opponentCardInHand1.SetTag(GameTag.CARDTYPE, (int)CardType.MINION);
 			_game.SecretsManager.OnEntityRevealedAsMinion(_opponentCardInHand1);
 

--- a/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
+++ b/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
@@ -60,11 +60,14 @@ namespace HDTTests.Hearthstone.Secrets
 			_heroPlayer = CreateNewEntity("HERO_01");
 			_heroPlayer.SetTag(GameTag.CARDTYPE, (int)CardType.HERO);
 			_heroPlayer.SetTag(GameTag.CONTROLLER, _heroPlayer.Id);
+			_heroPlayer.SetTag(GameTag.MULLIGAN_STATE, (int)Mulligan.DONE);
+			_heroPlayer.SetTag(GameTag.PLAYER_ID, _heroPlayer.Id);
 			_heroOpponent = CreateNewEntity("HERO_02");
 			_heroOpponent.SetTag(GameTag.CARDTYPE, (int)CardType.HERO);
 			_heroOpponent.SetTag(GameTag.CONTROLLER, _heroOpponent.Id);
 			_opponentEntity = CreateNewEntity("");
 			_opponentEntity.SetTag(GameTag.PLAYER_ID, _heroOpponent.Id);
+			_opponentEntity.SetTag(GameTag.MULLIGAN_STATE, (int)Mulligan.DONE);
 
 			_game.Entities.Add(0, _gameEntity);
 			_game.Entities.Add(1, _heroPlayer);
@@ -339,6 +342,54 @@ namespace HDTTests.Hearthstone.Secrets
 			_game.SecretsManager.OnEntityRevealedAsMinion(_opponentCardInHand1);
 
 			VerifySecrets(0, HunterSecrets.All, HunterSecrets.HiddenCache, HunterSecrets.Snipe);
+		}
+
+		[TestMethod]
+		public void MultipleSecrets_MinionPlayed_MinionDied()
+		{
+			_gameEventHandler.HandlePlayerMinionPlayed(_playerMinion1);
+			_gameEventHandler.HandlePlayerMinionDeath(_playerMinion1);
+			VerifySecrets(0, HunterSecrets.All);
+			VerifySecrets(1, MageSecrets.All, MageSecrets.FrozenClone);
+			VerifySecrets(2, PaladinSecrets.All);
+			VerifySecrets(3, RogueSecrets.All);
+		}
+
+		[TestMethod]
+		public void MultipleSecrets_MinionPlayed_SecretTriggered_MinionDied()
+		{
+			_gameEventHandler.HandleOpponentSecretPlayed(_secretMage2, "", 0, 0, Zone.HAND, _secretMage2.Id);
+			_secretMage2.CardId = MageSecrets.ExplosiveRunes;
+			_gameEventHandler.HandlePlayerMinionPlayed(_playerMinion1);
+			_gameEventHandler.HandleOpponentSecretTrigger(_secretMage2, "", 2, _secretMage1.Id);
+			_gameEventHandler.HandlePlayerMinionDeath(_playerMinion1);
+			VerifySecrets(0, HunterSecrets.All);
+			VerifySecrets(1, MageSecrets.All, MageSecrets.ExplosiveRunes, MageSecrets.FrozenClone);
+			VerifySecrets(2, PaladinSecrets.All);
+			VerifySecrets(3, RogueSecrets.All);
+		}
+
+		[TestMethod]
+		public void MultipleSecrets_MinionPlayed_MinionDiedNextTurn()
+		{
+			_gameEventHandler.HandlePlayerMinionPlayed(_playerMinion1);
+			_gameEventHandler.TurnStart(Hearthstone_Deck_Tracker.Enums.ActivePlayer.Player, 2);
+			_gameEventHandler.HandlePlayerMinionDeath(_playerMinion1);
+			VerifySecrets(0, HunterSecrets.All, HunterSecrets.Snipe);
+			VerifySecrets(1, MageSecrets.All, MageSecrets.ExplosiveRunes, MageSecrets.MirrorEntity, MageSecrets.PotionOfPolymorph, MageSecrets.FrozenClone);
+			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.Repentance);
+			VerifySecrets(3, RogueSecrets.All);
+		}
+
+		[TestMethod]
+		public void MultipleSecrets_MinionPlayed_AnotherMinionDied()
+		{
+			_gameEventHandler.HandlePlayerMinionPlayed(_playerMinion1);
+			_gameEventHandler.HandlePlayerMinionDeath(_playerMinion2);
+			VerifySecrets(0, HunterSecrets.All, HunterSecrets.Snipe);
+			VerifySecrets(1, MageSecrets.All, MageSecrets.ExplosiveRunes, MageSecrets.MirrorEntity, MageSecrets.PotionOfPolymorph, MageSecrets.FrozenClone);
+			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.Repentance);
+			VerifySecrets(3, RogueSecrets.All);
 		}
 
 		private void VerifySecrets(int index, List<string> allSecrets, params string[] triggered)

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -859,7 +859,7 @@ namespace Hearthstone_Deck_Tracker
 		{
 			_game.Player.PlayToGraveyard(entity, cardId, turn);
 			GameEvents.OnPlayerPlayToGraveyard.Execute((Card)entity.Card.Clone());
-			if (playersTurn && entity.IsMinion)
+			if(playersTurn && entity.IsMinion)
 				HandlePlayerMinionDeath(entity);
 		}
 

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -304,7 +304,10 @@ namespace Hearthstone_Deck_Tracker
 			var player = turn.Item1;
 			Log.Info($"--- {player} turn {turn.Item2} ---");
 			if(player == ActivePlayer.Player)
+			{
 				HandleThaurissanCostReduction();
+				_game.SecretsManager.HandleTurnStart();
+			}
 			GameEvents.OnTurnStart.Execute(player);
 			if(_turnQueue.Count > 0)
 				return;

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -216,16 +216,20 @@ namespace Hearthstone_Deck_Tracker
 				GameEvents.OnOpponentMinionAttack.Execute(attackInfo);
 		}
 
-		public void HandlePlayerMinionPlayed()
+		public void HandlePlayerMinionPlayed(Entity entity)
 		{
-			_game.SecretsManager.HandleMinionPlayed();
+			_game.SecretsManager.HandleMinionPlayed(entity);
 		}
 
 		public void HandleOpponentMinionDeath(Entity entity, int turn)
 		{
-			_game.SecretsManager.HandleMinionDeath(entity);
+			_game.SecretsManager.HandleOpponentMinionDeath(entity);
 		}
 
+		public void HandlePlayerMinionDeath(Entity entity)
+		{
+			_game.SecretsManager.HandlePlayerMinionDeath(entity);
+		}
 
 		public void HandleEntityPredamage(Entity entity, int value)
 		{
@@ -848,10 +852,12 @@ namespace Hearthstone_Deck_Tracker
 
 		public void HandleOpponentCreateInSetAside(Entity entity, int turn) => _game.Opponent.CreateInSetAside(entity, turn);
 
-		public void HandlePlayerPlayToGraveyard(Entity entity, string cardId, int turn)
+		public void HandlePlayerPlayToGraveyard(Entity entity, string cardId, int turn, bool playersTurn)
 		{
 			_game.Player.PlayToGraveyard(entity, cardId, turn);
 			GameEvents.OnPlayerPlayToGraveyard.Execute((Card)entity.Card.Clone());
+			if (playersTurn && entity.IsMinion)
+				HandlePlayerMinionDeath(entity);
 		}
 
 		public void HandleOpponentPlayToGraveyard(Entity entity, string cardId, int turn, bool playersTurn)

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
@@ -125,14 +125,19 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 
 			var exclude = new List<string>();
 
-			SaveSecret(Hunter.Snipe);			exclude.Add(Hunter.Snipe);
-			SaveSecret(Mage.ExplosiveRunes);	exclude.Add(Mage.ExplosiveRunes);
-			SaveSecret(Mage.PotionOfPolymorph);	exclude.Add(Mage.PotionOfPolymorph);
-			SaveSecret(Paladin.Repentance);		exclude.Add(Paladin.Repentance); 
+			SaveSecret(Hunter.Snipe);
+			exclude.Add(Hunter.Snipe);
+			SaveSecret(Mage.ExplosiveRunes);
+			exclude.Add(Mage.ExplosiveRunes);
+			SaveSecret(Mage.PotionOfPolymorph);
+			exclude.Add(Mage.PotionOfPolymorph);
+			SaveSecret(Paladin.Repentance);
+			exclude.Add(Paladin.Repentance);
 
 			if(FreeSpaceOnBoard)
 			{
-				SaveSecret(Mage.MirrorEntity);	exclude.Add(Mage.MirrorEntity);
+				SaveSecret(Mage.MirrorEntity);
+				exclude.Add(Mage.MirrorEntity);
 			}
 
 			if(FreeSpaceInHand)
@@ -204,10 +209,10 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 
 		public void HandlePlayerMinionDeath(Entity entity)
 		{
-			if (entity.Id == _lastPlayedMinionId && SavedSecrets.Count > 0)
+			if(entity.Id == _lastPlayedMinionId && SavedSecrets.Count > 0)
 			{
-				foreach (var savedSecret in SavedSecrets)
-					foreach (var secret in Secrets)
+				foreach(var savedSecret in SavedSecrets)
+					foreach(var secret in Secrets)
 						secret.Include(savedSecret);
 				Refresh();
 			}
@@ -318,7 +323,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 
 		public void SaveSecret(string secret)
 		{
-			if (!Secrets.Any(s => s.IsExcluded(secret)))
+			if(!Secrets.Any(s => s.IsExcluded(secret)))
 				SavedSecrets.Add(secret);
 		}
 

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
@@ -322,5 +322,9 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 				SavedSecrets.Add(secret);
 		}
 
+		public void HandleTurnStart()
+		{
+			SavedSecrets.Clear();
+		}
 	}
 }

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
@@ -14,6 +14,9 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 		private int _lastCompetitiveSpiritCheck;
 		private HashSet<Entity> EntititesInHandOnMinionsPlayed = new HashSet<Entity>();
 
+		private int _lastPlayedMinionId;
+		protected List<string> SavedSecrets = new List<string>();
+
 		private bool FreeSpaceOnBoard => Game.OpponentMinionCount < 7;
 		private bool FreeSpaceInHand => Game.OpponentHandCount < 10;
 		private bool HandleAction => HasActiveSecrets && Config.Instance.AutoGrayoutSecrets;
@@ -25,6 +28,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 		protected abstract bool HasActiveSecrets { get; }
 		public abstract bool Exclude(string cardId, bool invokeCallback = true);
 		public abstract void Exclude(List<string> cardIds);
+		public abstract void Refresh();
 
 		public virtual void Reset()
 		{
@@ -112,20 +116,24 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 				HandleAttack(attacker, defender, true);
 		}
 
-		public void HandleMinionPlayed()
+		public void HandleMinionPlayed(Entity entity)
 		{
 			if(!HandleAction)
 				return;
 
+			_lastPlayedMinionId = entity.Id;
+
 			var exclude = new List<string>();
 
-			exclude.Add(Hunter.Snipe);
-			exclude.Add(Mage.ExplosiveRunes);
-			exclude.Add(Mage.PotionOfPolymorph);
-			exclude.Add(Paladin.Repentance);
+			SaveSecret(Hunter.Snipe);			exclude.Add(Hunter.Snipe);
+			SaveSecret(Mage.ExplosiveRunes);	exclude.Add(Mage.ExplosiveRunes);
+			SaveSecret(Mage.PotionOfPolymorph);	exclude.Add(Mage.PotionOfPolymorph);
+			SaveSecret(Paladin.Repentance);		exclude.Add(Paladin.Repentance); 
 
 			if(FreeSpaceOnBoard)
-				exclude.Add(Mage.MirrorEntity);
+			{
+				SaveSecret(Mage.MirrorEntity);	exclude.Add(Mage.MirrorEntity);
+			}
 
 			if(FreeSpaceInHand)
 				exclude.Add(Mage.FrozenClone);
@@ -142,7 +150,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 			Exclude(exclude);
 		}
 
-		public void HandleMinionDeath(Entity entity)
+		public void HandleOpponentMinionDeath(Entity entity)
 		{
 			if(!HandleAction)
 				return;
@@ -194,6 +202,17 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 			Exclude(exclude);
 		}
 
+		public void HandlePlayerMinionDeath(Entity entity)
+		{
+			if (entity.Id == _lastPlayedMinionId && SavedSecrets.Count > 0)
+			{
+				foreach (var savedSecret in SavedSecrets)
+					foreach (var secret in Secrets)
+						secret.Include(savedSecret);
+				Refresh();
+			}
+		}
+
 		public async void HandleAvengeAsync(int deathRattleCount)
 		{
 			if(!HandleAction)
@@ -238,6 +257,8 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 		{
 			if(!HandleAction)
 				return;
+
+			SavedSecrets.Clear();
 
 			var exclude = new List<string>();
 
@@ -294,5 +315,12 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 			if (secret.Entity.IsClass(CardClass.HUNTER))
 				EntititesInHandOnMinionsPlayed.Clear();
 		}
+
+		public void SaveSecret(string secret)
+		{
+			if (!Secrets.Any(s => s.IsExcluded(secret)))
+				SavedSecrets.Add(secret);
+		}
+
 	}
 }

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsManager.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsManager.cs
@@ -27,6 +27,11 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 			OnSecretsChanged?.Invoke(new List<Card>());
 		}
 
+		public override void Refresh()
+		{
+			OnSecretsChanged?.Invoke(GetSecretList());
+		}
+
 		public bool NewSecret(Entity entity)
 		{
 			if(entity == null || !entity.IsSecret || !entity.HasTag(GameTag.CLASS))
@@ -36,7 +41,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 			var secret = new Secret(entity);
 			Secrets.Add(secret);
 			OnNewSecret(secret);
-			OnSecretsChanged?.Invoke(GetSecretList());
+			Refresh();
 			Log.Info(entity.ToString());
 			return true;
 		}
@@ -51,8 +56,11 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 				HandleFastCombat(entity);
 				Secrets.Remove(secret);
 				if(secret.Entity.HasCardId)
+				{ 
 					Exclude(secret.Entity.CardId, false);
-				OnSecretsChanged?.Invoke(GetSecretList());
+					SavedSecrets.Remove(secret.Entity.CardId);
+				}
+				Refresh();
 				return true;
 			}
 			Log.Info("Secret not found: " + entity);
@@ -73,7 +81,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 				secret.Exclude(cardId);
 			Log.Info("Excluded Secret " + cardId);
 			if(invokeCallback)
-				OnSecretsChanged?.Invoke(GetSecretList());
+				Refresh();
 			return true;
 		}
 
@@ -87,7 +95,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 			}
 			else
 				Exclude(cardId, false);
-			OnSecretsChanged?.Invoke(GetSecretList());
+			Refresh();
 		}
 
 		public List<Card> GetSecretList()

--- a/Hearthstone Deck Tracker/IGameHandler.cs
+++ b/Hearthstone Deck Tracker/IGameHandler.cs
@@ -35,7 +35,7 @@ namespace Hearthstone_Deck_Tracker
 		void HandleOpponentFatigue(int currentDamage);
 
 		void HandleOpponentJoust(Entity entity, string cardId, int turn);
-		void HandlePlayerPlayToGraveyard(Entity entity, string cardId, int turn);
+		void HandlePlayerPlayToGraveyard(Entity entity, string cardId, int turn, bool playersTurn);
 		void HandleOpponentPlayToGraveyard(Entity entity, string cardId, int turn, bool playersTurn);
 		void HandlePlayerCreateInPlay(Entity entity, string cardId, int turn);
 		void HandleOpponentCreateInPlay(Entity entity, string cardId, int turn);
@@ -54,7 +54,8 @@ namespace Hearthstone_Deck_Tracker
 
 		void HandleAttackingEntity(Entity entity);
 		void HandleDefendingEntity(Entity entity);
-		void HandlePlayerMinionPlayed();
+		void HandlePlayerMinionPlayed(Entity entity);
+		void HandlePlayerMinionDeath(Entity entity);
 		void HandleOpponentMinionDeath(Entity entity, int turn);
 		void HandleOpponentDamage(Entity entity);
 		void HandleTurnsInPlayChange(Entity entity, int turn);

--- a/Hearthstone Deck Tracker/LogReader/Handlers/TagChangeActions.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/TagChangeActions.cs
@@ -168,7 +168,7 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 						StringComparison.CurrentCultureIgnoreCase) ?? false)
 					return;
 			}
-			gameState.GameHandler.HandlePlayerMinionPlayed();
+			gameState.GameHandler.HandlePlayerMinionPlayed(entity);
 		}
 
 		private void DefendingChange(IHsGameState gameState, int id, IGame game, int value)
@@ -453,7 +453,7 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 					break;
 				case GRAVEYARD:
 					if(controller == game.Player.Id)
-						gameState.GameHandler.HandlePlayerPlayToGraveyard(entity, cardId, gameState.GetTurnNumber());
+						gameState.GameHandler.HandlePlayerPlayToGraveyard(entity, cardId, gameState.GetTurnNumber(), game.PlayerEntity?.IsCurrentPlayer ?? false);
 					else if(controller == game.Opponent.Id)
 						gameState.GameHandler.HandleOpponentPlayToGraveyard(entity, cardId, gameState.GetTurnNumber(), game.PlayerEntity?.IsCurrentPlayer ?? false);
 					break;


### PR DESCRIPTION
Now, if minion dies after explosive runes or snipe, other secrets still display

<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
