### PR TITLE
Fix a Freezing Trap issue #3830

### DIFF
--- a/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
+++ b/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
@@ -150,6 +150,7 @@ namespace HDTTests.Hearthstone.Secrets
 		public void SingleSecret_HeroToHero_PlayerAttackTest()
 		{
 			_playerMinion1.SetTag(GameTag.ZONE, (int)Zone.HAND);
+			_heroPlayer.SetTag(GameTag.HEALTH, Database.GetCardFromId(_heroPlayer.CardId).Health);
 			_game.SecretsManager.HandleAttack(_heroPlayer, _heroOpponent);
 			VerifySecrets(0, HunterSecrets.All, HunterSecrets.BearTrap, HunterSecrets.ExplosiveTrap, HunterSecrets.WanderingMonster);
 			VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier);
@@ -170,6 +171,7 @@ namespace HDTTests.Hearthstone.Secrets
 		public void SingleSecret_MinionToHero_PlayerAttackTest()
 		{
 			_playerMinion1.SetTag(GameTag.ZONE, (int)Zone.PLAY);
+			_playerMinion1.SetTag(GameTag.HEALTH, Database.GetCardFromId(_playerMinion1.CardId).Health);
 			_game.SecretsManager.HandleAttack(_playerMinion1, _heroOpponent);
 			VerifySecrets(0, HunterSecrets.All, HunterSecrets.BearTrap, HunterSecrets.ExplosiveTrap,
 				HunterSecrets.FreezingTrap, HunterSecrets.Misdirection, HunterSecrets.WanderingMonster);

--- a/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
+++ b/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
@@ -351,6 +351,19 @@ namespace HDTTests.Hearthstone.Secrets
 		}
 
 		[TestMethod]
+		public void MultipleSecrets_MinionToHero_ExplosiveTrapTriggered_MinionDied_PlayerAttackTest()
+		{
+			_playerMinion1.SetTag(GameTag.ZONE, (int)Zone.PLAY);
+			_playerMinion1.SetTag(GameTag.HEALTH, -1);
+			_game.SecretsManager.HandleAttack(_playerMinion1, _heroOpponent);
+			VerifySecrets(0, HunterSecrets.All, HunterSecrets.ExplosiveTrap,
+				HunterSecrets.Misdirection, HunterSecrets.WanderingMonster);
+			VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier, MageSecrets.Vaporize);
+			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.NobleSacrifice);
+			VerifySecrets(3, RogueSecrets.All);
+		}
+
+		[TestMethod]
 		public void MultipleSecrets_MinionPlayed_MinionDied()
 		{
 			_gameEventHandler.HandlePlayerMinionPlayed(_playerMinion1);

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
@@ -75,7 +75,8 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 				if(attacker.IsMinion)
 				{
 					exclude.Add(Mage.Vaporize);
-					exclude.Add(Hunter.FreezingTrap);
+					if(attacker.Health >= 1)
+						exclude.Add(Hunter.FreezingTrap);
 				}
 			}
 			else

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
@@ -56,7 +56,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 			{
 				if(!fastOnly)
 				{
-					if(freeSpaceOnBoard)
+					if(freeSpaceOnBoard && attacker.Health >= 1)
 						exclude.Add(Hunter.BearTrap);
 					exclude.Add(Mage.IceBarrier);
 				}


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

In https://hearthstone.gamepedia.com/Advanced_rulebook#Combat , blizzard write that
"If you play Explosive Trap then Freezing Trap, your enemy's Novice Engineer attacking into it will trigger the Explosive Trap and be reduced to -1 Health. The Freezing Trap is a hindering Secret and thus aborts having no target it considers valid.[30] "