### PR TITLE
Added Achievements log watcher to API

### DIFF
--- a/Hearthstone Deck Tracker/API/LogEvents.cs
+++ b/Hearthstone Deck Tracker/API/LogEvents.cs
@@ -2,6 +2,7 @@
 {
 	public class LogEvents
 	{
+		public static readonly ActionList<string> OnAchievementsLogLine = new ActionList<string>();
 		public static readonly ActionList<string> OnArenaLogLine = new ActionList<string>();
 		public static readonly ActionList<string> OnAssetLogLine = new ActionList<string>();
 		public static readonly ActionList<string> OnBobLogLine = new ActionList<string>();

--- a/Hearthstone Deck Tracker/LogReader/LogWatcherManager.cs
+++ b/Hearthstone Deck Tracker/LogReader/LogWatcherManager.cs
@@ -31,6 +31,7 @@ namespace Hearthstone_Deck_Tracker.LogReader
 		private readonly LogWatcher _logWatcher;
 		private bool _stop;
 
+		public static LogWatcherInfo AchievementsLogWatcherInfo => new LogWatcherInfo { Name = "Achievements" };
 		public static LogWatcherInfo PowerLogWatcherInfo => new LogWatcherInfo
 		{
 			Name = "Power",
@@ -47,6 +48,7 @@ namespace Hearthstone_Deck_Tracker.LogReader
 		{
 			_logWatcher = new LogWatcher(new []
 			{
+				AchievementsLogWatcherInfo,
 				PowerLogWatcherInfo,
 				GameplayLogWatcherInfo,
 				ArenaLogWatcherInfo,
@@ -125,6 +127,9 @@ namespace Hearthstone_Deck_Tracker.LogReader
 				_game.GameTime.Time = line.Time;
 				switch(line.Namespace)
 				{
+					case "Achievements":
+						OnAchievementsLogLine.Execute(line.Line);
+						break;
 					case "Power":
 						if(line.LineContent.StartsWith("GameState."))
 							_game.PowerLog.Add(line.Line);


### PR DESCRIPTION
Since the Rachelle log is gone, the Achievements log is the only one that contains GOLD_REWARD messages. This is what the Treasury plugin needs to track quests.

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
