### PR TITLE
Fix cards tracking for Spirit of the Dead

### DIFF
--- a/Hearthstone Deck Tracker/Hearthstone/Player.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Player.cs
@@ -33,6 +33,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		public int SpellsPlayedCount { get; private set; }
 		public bool IsPlayingWhizbang { get; set; }
 		public int PogoHopperPlayedCount {get; private set;}
+		public string LastDiedMinionCardId { get; set; }
 
 		public bool HasCoin => Hand.Any(e => e.CardId == HearthDb.CardIds.NonCollectible.Neutral.TheCoin);
 		public int HandCount => Hand.Count();
@@ -390,6 +391,8 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		public void PlayToGraveyard(Entity entity, string cardId, int turn)
 		{
 			entity.Info.Turn = turn;
+			if(entity.IsMinion)
+				LastDiedMinionCardId = cardId;
 			Log(entity);
 		}
 

--- a/Hearthstone Deck Tracker/LogReader/Handlers/PowerHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/PowerHandler.cs
@@ -234,6 +234,7 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 				var blockType = match.Success ? match.Groups["type"].Value : null;
 				var cardId = match.Success ? match.Groups["Id"].Value : null;
 				var target = GetTargetCardId(match);
+				var correspondPlayer = match.Success ? int.Parse(match.Groups["player"].Value) : -1;
 				gameState.BlockStart(blockType, cardId, target);
 
 				if(match.Success && (blockType == "TRIGGER" || blockType == "POWER"))
@@ -328,6 +329,13 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 							case Collectible.Warrior.Wrenchcalibur:
 								AddKnownCardId(gameState, NonCollectible.Neutral.SeaforiumBomber_BombToken);
 								break;
+							case Collectible.Priest.SpiritOfTheDead:
+								if(correspondPlayer == game.Player.Id)
+									AddKnownCardId(gameState, game.Player.LastDiedMinionCardId);
+								else if(correspondPlayer == game.Opponent.Id)
+									AddKnownCardId(gameState, game.Opponent.LastDiedMinionCardId);
+								break;
+
 						}
 					}
 					else //POWER

--- a/Hearthstone Deck Tracker/LogReader/LogConstants.cs
+++ b/Hearthstone Deck Tracker/LogReader/LogConstants.cs
@@ -25,7 +25,7 @@ namespace Hearthstone_Deck_Tracker.LogReader
 		public static class PowerTaskList
 		{
 			public static readonly Regex BlockStartRegex =
-				new Regex(@".*BLOCK_START.*BlockType=(?<type>(\w+)).*id=(?<id>\d*).*(cardId=(?<Id>(\w*))).*player=(?<player>\d*).*EffectCardId=(?<effectCardId>(.*))\sEffectIndex=.*Target=(?<target>(.+)).*SubOption=(?<subOption>(.+))");
+				new Regex(@".*BLOCK_START.*BlockType=(?<type>(\w+)).*id=(?<id>\d*).*(cardId=(?<Id>(\w*))).*player=(?<player>\d).*EffectCardId=(?<effectCardId>(.*))\sEffectIndex=.*Target=(?<target>(.+)).*SubOption=(?<subOption>(.+))");
 
 			public static readonly Regex CardIdRegex = new Regex(@"cardId=(?<cardId>(\w+))");
 			public static readonly Regex CreationRegex = new Regex(@"FULL_ENTITY - Updating.*id=(?<id>(\d+)).*zone=(?<zone>(\w+)).*CardID=(?<cardId>(\w*))");

--- a/Hearthstone Deck Tracker/LogReader/LogConstants.cs
+++ b/Hearthstone Deck Tracker/LogReader/LogConstants.cs
@@ -25,7 +25,7 @@ namespace Hearthstone_Deck_Tracker.LogReader
 		public static class PowerTaskList
 		{
 			public static readonly Regex BlockStartRegex =
-				new Regex(@".*BLOCK_START.*BlockType=(?<type>(\w+)).*id=(?<id>\d*).*(cardId=(?<Id>(\w*))).*EffectCardId=(?<effectCardId>(.*))\sEffectIndex=.*Target=(?<target>(.+)).*SubOption=(?<subOption>(.+))");
+				new Regex(@".*BLOCK_START.*BlockType=(?<type>(\w+)).*id=(?<id>\d*).*(cardId=(?<Id>(\w*))).*player=(?<player>\d*).*EffectCardId=(?<effectCardId>(.*))\sEffectIndex=.*Target=(?<target>(.+)).*SubOption=(?<subOption>(.+))");
 
 			public static readonly Regex CardIdRegex = new Regex(@"cardId=(?<cardId>(\w+))");
 			public static readonly Regex CreationRegex = new Regex(@"FULL_ENTITY - Updating.*id=(?<id>(\d+)).*zone=(?<zone>(\w+)).*CardID=(?<cardId>(\w*))");


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

The card 'Spirit of the Dead' is getting some popularity recently, so this PR tries to fix the card tracking issue (fixes #3841).
Trackers are now able to track those card copies generated by the card 'Spirit of the Dead' for both the player and the opponent.
