### PR TITLE
Fix secret handling when a minion tries to attack hero but is removed from play

### DIFF
--- a/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
+++ b/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
@@ -370,7 +370,7 @@ namespace HDTTests.Hearthstone.Secrets
 			_game.SecretsManager.HandleAttack(_playerMinion1, _heroOpponent);
 			VerifySecrets(0, HunterSecrets.All, HunterSecrets.ExplosiveTrap,
 				HunterSecrets.Misdirection, HunterSecrets.WanderingMonster);
-			VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier, MageSecrets.Vaporize, MageSecrets.FlameWard);
+			VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier);
 			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.NobleSacrifice);
 			VerifySecrets(3, RogueSecrets.All);
 		}
@@ -437,6 +437,27 @@ namespace HDTTests.Hearthstone.Secrets
 			VerifySecrets(0, HunterSecrets.All, HunterSecrets.Snipe);
 			VerifySecrets(1, MageSecrets.All, MageSecrets.ExplosiveRunes, MageSecrets.MirrorEntity, MageSecrets.PotionOfPolymorph, MageSecrets.FrozenClone);
 			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.Repentance);
+			VerifySecrets(3, RogueSecrets.All);
+		}
+
+		[TestMethod]
+		public void MultipleSecrets_MinionAttackHero_MinionDied()
+		{
+			_gameEventHandler.HandleOpponentSecretPlayed(_secretMage2, "", 0, 0, Zone.HAND, _secretMage2.Id);
+			_secretMage2.CardId = MageSecrets.Vaporize;
+
+			_playerMinion1.SetTag(GameTag.ZONE, (int)Zone.PLAY);
+			_playerMinion1.SetTag(GameTag.HEALTH, Database.GetCardFromId(_playerMinion1.CardId).Health);
+			_game.ProposedAttacker = _playerMinion1.Id;
+			_game.ProposedDefender = _heroOpponent.Id;
+			// Combat Preparation Phase: Vaporize is triggered and _playerMinion1 exits the combat
+			_playerMinion1.SetTag(GameTag.SHOULDEXITCOMBAT, 1);
+			_gameEventHandler.HandleOpponentSecretTrigger(_secretMage2, "", 2, _secretMage1.Id);
+
+			VerifySecrets(0, HunterSecrets.All, HunterSecrets.ExplosiveTrap, HunterSecrets.WanderingMonster);
+			// TODO: MageSecrets.IceBarrier should be triggered here
+			VerifySecrets(1, MageSecrets.All, MageSecrets.Vaporize);
+			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.NobleSacrifice);
 			VerifySecrets(3, RogueSecrets.All);
 		}
 

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
@@ -66,18 +66,22 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 
 				exclude.Add(Hunter.ExplosiveTrap);
 
-				if(Game.IsMinionInPlay)
+				if(!attacker.HasTag(GameTag.SHOULDEXITCOMBAT) && Game.IsMinionInPlay)
 					exclude.Add(Hunter.Misdirection);
-
-				if(attacker.IsMinion && Game.PlayerMinionCount > 1)
-					exclude.Add(Rogue.SuddenBetrayal);
 
 				if(attacker.IsMinion)
 				{
-					exclude.Add(Mage.Vaporize);
-					exclude.Add(Mage.FlameWard);
-					if(attacker.Health >= 1)
+					// attacker is not exiting combat(e.g., because of Vaporize or Freezing Trap)
+					// nor it is mortally wounded(e.g., caused by ExplosiveTrap)
+					if(!attacker.HasTag(GameTag.SHOULDEXITCOMBAT) && attacker.Health >= 1)
+					{
+						if(Game.PlayerMinionCount > 1)
+							exclude.Add(Rogue.SuddenBetrayal);
+
+						exclude.Add(Mage.FlameWard);
 						exclude.Add(Hunter.FreezingTrap);
+						exclude.Add(Mage.Vaporize);
+					}
 				}
 			}
 			else


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

This fixes #3961 

A minion who tries to attack enemy hero might be removed from play due to:
1. Vaporize or Freezing Trap: tag SHOULDEXITCOMBAT is set to 1
2. Explosive Trap: minion's health less than 1

In these cases, the following secrets won't be triggered:
1. Misdirection(if Vaporize is played first)
2. Sudden Betrayal
3. Flame Ward
4. Freezing Trap(if Vaporize is played first, or if Explosive Trap that kills the minion is triggered first)
5. Vaporize(if Freezing Trap is played first,  or if Explosive Trap that kills the minion is triggered first)

Secret handling is now fixed for these cases.

TODO:
Ice Barrier is not correctly grayed out when I do the tests. See #3963 
