### PR TITLE
Fix HSReplay.net deck short id generation

### DIFF
--- a/HDTTests/HDTTests.csproj
+++ b/HDTTests/HDTTests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Hearthstone\WebImportTest.cs" />
     <Compile Include="Hearthstone\DeckTest.cs" />
     <Compile Include="Hearthstone\CardDbTest.cs" />
+    <Compile Include="HsReplay\Utility\ShortIdHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="LocUtilTests.cs" />
     <Compile Include="Utility\Twitch\TwitchApiHelperTests.cs" />

--- a/HDTTests/HsReplay/Utility/ShortIdHelperTests.cs
+++ b/HDTTests/HsReplay/Utility/ShortIdHelperTests.cs
@@ -1,0 +1,48 @@
+using HearthDb.Deckstrings;
+using Hearthstone_Deck_Tracker.Hearthstone;
+using Hearthstone_Deck_Tracker.HsReplay.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HDTTests.HsReplay.Utility
+{
+	[TestClass]
+	public class ShortIdHelperTests
+	{
+		[TestMethod]
+		public void BasicMageDeck_ValidShortId()
+		{
+			var hearthDbDeck = DeckSerializer.Deserialize("AAECAf0EAA9NWtgBtAK7AosDqwS0BOAE+wSWBYoH7AeeCZYNAA==");
+			var deck = HearthDbConverter.FromHearthDbDeck(hearthDbDeck);
+			var shortid = ShortIdHelper.GetShortId(deck);
+			Assert.AreEqual(shortid, "KtYDbAkM8IjSSyLMWQn5zb");
+		}
+
+		[TestMethod]
+		public void ComboPriest_ValidShortId()
+		{
+			var hearthDbDeck = DeckSerializer.Deserialize("AAECAa0GBqUJ+wzl9wLQ/gKnhwOppQMM+ALlBPYH1QjRCtIK8gz3DK+lA9KlA/2nA4SoAwA=");
+			var deck = HearthDbConverter.FromHearthDbDeck(hearthDbDeck);
+			var shortid = ShortIdHelper.GetShortId(deck);
+			Assert.AreEqual(shortid, "0gsPp02q8ajKsGVstRwLpb");
+		}
+
+		[TestMethod]
+		public void HighlanderHunter_ValidShortId()
+		{
+			var hearthDbDeck = DeckSerializer.Deserialize("AAECAR8engGoArUDxwOHBMkErgbFCNsJ7Qn+DJjwAp7wAu/xAqCAA6eCA5uFA/WJA+aWA/mWA76YA7acA56dA/yjA+WkA5+lA6KlA6alA4SnA5+3AwAA");
+			var deck = HearthDbConverter.FromHearthDbDeck(hearthDbDeck);
+			var shortid = ShortIdHelper.GetShortId(deck);
+			Assert.AreEqual(shortid, "O2VpFDQokIrwww8iOmE3Lc");
+		}
+
+		[TestMethod]
+		public void CardIdCollisionDeck_ValidShortId()
+		{
+			var hearthDbDeck = DeckSerializer.Deserialize("AAEBAf0EHnGeAcABwwG7Au4CqwSWBewF9w2JDroWwxbXtgLrugLYuwLZuwKHvQLBwQKP0wKi0wLu9gKnggP1iQP8owOSpAO+pAO/pAPdqQP0qwMAAA==");
+			var deck = HearthDbConverter.FromHearthDbDeck(hearthDbDeck);
+			var shortid = ShortIdHelper.GetShortId(deck);
+			Assert.AreEqual(shortid, "mA9O7wXvzxMsx1KO7EuFve");
+		}
+
+	}
+}

--- a/Hearthstone Deck Tracker/HsReplay/Utility/ShortIdHelper.cs
+++ b/Hearthstone Deck Tracker/HsReplay/Utility/ShortIdHelper.cs
@@ -56,9 +56,12 @@ namespace Hearthstone_Deck_Tracker.HsReplay.Utility
 		{
 			if(x == y)
 				return 0;
-			var val = x.Zip(y, Utf8Compare).FirstOrDefault(v => v != 0);
-			if(val != 0)
-				return val;
+			var val1 = x.ToLower().Zip(y.ToLower(), Utf8Compare).FirstOrDefault(v => v != 0);
+			if(val1 != 0)
+				return val1;
+			var val2 = x.Zip(y, Utf8Compare).FirstOrDefault(v => v != 0);
+			if(val2 != 0)
+				return val2;
 			return x.Length - y.Length;
 		}
 


### PR DESCRIPTION
This PR fixes short id generation to mirror https://github.com/HearthSim/hsredshift/pull/169. Previously we used an incorrect comparison method, whereas we want a mostly compatible Unicode Collation Algorithm. For us this means in practice we want a case-insensitive comparison step before the case-sensitive comparison.

Internally refs HSR-462.