### PR TITLE
Fix Bad Luck Albatross

### DIFF
--- a/Hearthstone Deck Tracker/LogReader/Handlers/PowerHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/PowerHandler.cs
@@ -348,7 +348,7 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 								AddKnownCardId(gameState, NonCollectible.Rogue.Waxadred_WaxadredsCandleToken);
 								break;
 							case Collectible.Neutral.BadLuckAlbatross:
-								AddKnownCardId(gameState, NonCollectible.Neutral.BadLuckAlbatross_AlbatrossToken);
+								AddKnownCardId(gameState, NonCollectible.Neutral.BadLuckAlbatross_AlbatrossToken, 2);
 								break;
 							case Collectible.Priest.ReliquaryOfSouls:
 								AddKnownCardId(gameState, NonCollectible.Priest.ReliquaryofSouls_ReliquaryPrimeToken);


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

This fixes #4010 

One of the two albatrosses created by Bad Luck Albatross is not tracked as  `GuessedCardState.Guessed`, which causes the leak.