### PR TITLE
Implement Madame Lazul card tracking

### DIFF
--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -974,6 +974,11 @@ namespace Hearthstone_Deck_Tracker
 			Core.UpdateOpponentCards();
 		}
 
+		public void HandleCardCopy()
+		{
+			Core.UpdateOpponentCards();
+		}
+
 		public void HandlePlayerJoust(Entity entity, string cardId, int turn)
 		{
 			_game.Player.JoustReveal(entity, turn);

--- a/Hearthstone Deck Tracker/IGameHandler.cs
+++ b/Hearthstone Deck Tracker/IGameHandler.cs
@@ -85,5 +85,6 @@ namespace Hearthstone_Deck_Tracker
 		void HandleChameleosReveal(string cardId);
 		void HandleBeginMulligan();
 		void HandlePlayerMulliganDone();
+		void HandleCardCopy();
 	}
 }

--- a/Hearthstone Deck Tracker/LogReader/Handlers/TagChangeActions.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/TagChangeActions.cs
@@ -75,7 +75,7 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 			if(!game.Entities.TryGetValue(value, out var targetEntity))
 				return;
 
-			if(string.IsNullOrEmpty(targetEntity.CardId) && targetEntity.IsInHand)
+			if(string.IsNullOrEmpty(targetEntity.CardId))
 			{
 				targetEntity.CardId = entity.CardId;
 				targetEntity.Info.GuessedCardState = GuessedCardState.Guessed;


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

This PR implements cards tracking for `Madame Lazul` and other similar cards(e.g. `Mind Vision`).

The tag `COPIED_FROM_ENTITY_ID` is used when:
1. discover or copy cards from the opponent's hand, e.g. `Maname Lazul`, `Mind Vision`  <== _This is what we want to keep track of_
2. discover or copy cards from the opponent's deck, e.g. `Cloning Device`, `Thoughtsteal`
3. discover cards from own deck, e.g. `Tracking`, `Sightless Watcher`

Since it doesn't help much knowing which cards are in the opponent's deck, here we only keep track of known cards that are in the opponent's hand. And also, we don't want to handle cards copying initiated by the opponent to avoid info leak.