### PR TITLE
Fix secret handling when attack happens

### DIFF
--- a/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
+++ b/HDTTests/Hearthstone/Secrets/SecretEventHandlerTest.cs
@@ -399,7 +399,7 @@ namespace HDTTests.Hearthstone.Secrets
 			_game.SecretsManager.HandleAttack(_playerMinion1, _heroOpponent);
 			VerifySecrets(0, HunterSecrets.All, HunterSecrets.ExplosiveTrap,
 				HunterSecrets.WanderingMonster);
-			VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier, MageSecrets.Vaporize, MageSecrets.FlameWard);
+			VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier);
 			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.NobleSacrifice);
 			VerifySecrets(3, RogueSecrets.All);
 		}
@@ -467,6 +467,45 @@ namespace HDTTests.Hearthstone.Secrets
 			VerifySecrets(1, MageSecrets.All, MageSecrets.ExplosiveRunes, MageSecrets.MirrorEntity, MageSecrets.PotionOfPolymorph, MageSecrets.FrozenClone);
 			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.Repentance);
 			VerifySecrets(3, RogueSecrets.All, RogueSecrets.Ambush);
+		}
+
+
+		[TestMethod]
+		public void MultipleSecrets_MinionToHero_VaporizeTriggered_PlayerAttackTest()
+		{
+			_gameEventHandler.HandleOpponentSecretPlayed(_secretMage2, "", 0, 0, Zone.HAND, _secretMage2.Id);
+			_secretMage2.CardId = MageSecrets.Vaporize;
+
+			_playerMinion1.SetTag(GameTag.ZONE, (int)Zone.PLAY);
+			_playerMinion1.SetTag(GameTag.HEALTH, Database.GetCardFromId(_playerMinion1.CardId).Health);
+			_game.ProposedAttacker = _playerMinion1.Id;
+			_game.ProposedDefender = _heroOpponent.Id;
+			_gameEventHandler.HandleOpponentSecretTrigger(_secretMage2, "", 2, _secretMage2.Id);
+
+			VerifySecrets(0, HunterSecrets.All, HunterSecrets.ExplosiveTrap, HunterSecrets.WanderingMonster);
+			VerifySecrets(1, MageSecrets.All, MageSecrets.Vaporize, MageSecrets.IceBarrier);
+			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.NobleSacrifice);
+			VerifySecrets(3, RogueSecrets.All);
+		}
+
+		[TestMethod]
+		public void MultipleSecrets_MinionToMinion_FreezingTrapTriggered_PlayerAttackTest()
+		{
+			_gameEventHandler.HandleOpponentSecretPlayed(_secretHunter2, "", 0, 0, Zone.HAND, _secretHunter2.Id);
+			_secretHunter2.CardId = HunterSecrets.FreezingTrap;
+
+			_playerMinion1.SetTag(GameTag.ZONE, (int)Zone.PLAY);
+			_playerMinion1.SetTag(GameTag.HEALTH, Database.GetCardFromId(_playerMinion1.CardId).Health);
+			_opponentMinion1.SetTag(GameTag.ZONE, (int)Zone.PLAY);
+			_opponentMinion1.SetTag(GameTag.HEALTH, Database.GetCardFromId(_opponentMinion1.CardId).Health);
+			_game.ProposedAttacker = _playerMinion1.Id;
+			_game.ProposedDefender = _opponentMinion1.Id;
+			_gameEventHandler.HandleOpponentSecretTrigger(_secretHunter2, "", 2, _secretHunter2.Id);
+
+			VerifySecrets(0, HunterSecrets.All, HunterSecrets.FreezingTrap, HunterSecrets.PackTactics, HunterSecrets.SnakeTrap, HunterSecrets.VenomstrikeTrap);
+			VerifySecrets(1, MageSecrets.All, MageSecrets.SplittingImage);
+			VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.AutodefenseMatrix, PaladinSecrets.NobleSacrifice);
+			VerifySecrets(3, RogueSecrets.All, RogueSecrets.Bamboozle);
 		}
 
 		private void VerifySecrets(int index, List<string> allSecrets, params string[] triggered)

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretsEventHandler.cs
@@ -54,36 +54,35 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 
 			if(defender.IsHero)
 			{
-				if(!fastOnly)
+				if(!fastOnly && attacker.Health >= 1)
 				{
-					if(freeSpaceOnBoard && attacker.Health >= 1)
+					if(freeSpaceOnBoard)
 						exclude.Add(Hunter.BearTrap);
-					exclude.Add(Mage.IceBarrier);
-				}
 
-				if(freeSpaceOnBoard)
-					exclude.Add(Hunter.WanderingMonster);
-
-				exclude.Add(Hunter.ExplosiveTrap);
-				
-				if(Game.Entities.Values.Any(x =>
+					if(Game.Entities.Values.Any(x =>
 													x.IsInPlay &&
 													(x.IsHero || x.IsMinion) &&
 													!x.HasTag(GameTag.IMMUNE) &&
 													x != attacker &&
 													x != defender))
-					exclude.Add(Hunter.Misdirection);
+						exclude.Add(Hunter.Misdirection);
 
-				if(attacker.IsMinion && Game.PlayerMinionCount > 1)
-					exclude.Add(Rogue.SuddenBetrayal);
+					if(attacker.IsMinion)
+					{
+						if(Game.PlayerMinionCount > 1)
+							exclude.Add(Rogue.SuddenBetrayal);
 
-				if(attacker.IsMinion)
-				{
-					exclude.Add(Mage.Vaporize);
-					exclude.Add(Mage.FlameWard);
-					if(attacker.Health >= 1)
+						exclude.Add(Mage.FlameWard);
 						exclude.Add(Hunter.FreezingTrap);
+						exclude.Add(Mage.Vaporize);
+					}
 				}
+
+				if(freeSpaceOnBoard)
+					exclude.Add(Hunter.WanderingMonster);
+
+				exclude.Add(Mage.IceBarrier);
+				exclude.Add(Hunter.ExplosiveTrap);
 			}
 			else
 			{
@@ -95,11 +94,8 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Secrets
 				{
 					exclude.Add(Mage.SplittingImage);
 					exclude.Add(Hunter.PackTactics);
-					if(!fastOnly)
-					{
-						exclude.Add(Hunter.SnakeTrap);
-						exclude.Add(Hunter.VenomstrikeTrap);
-					}
+					exclude.Add(Hunter.SnakeTrap);
+					exclude.Add(Hunter.VenomstrikeTrap);
 				}
 
 				if(attacker.IsMinion)


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

This PR fixes several secret predictions when an attack happens:
- exclude `IceBarrier` if it is not triggered, no matter whether the attacker is removed from the play
- leave `Misdirection`/`SuddenBetrayal`/`Vaporize`/`FlameWard`/`FreezingTrap` in the pool of possibilities if they are not triggered when the attacker is removed from the play by secret like `Vaporize`/`FreezingTrap`
- exclude `SnakeTrap`/`VenomstrikeTrap` if they are not triggered, no matter whether the attacker is removed from the play by secret like `FreezingTrap`

Two test cases are added.

This will
- fix #3963 
- fix #3961
- fix #3850 