### PR TITLE
Automatically hide player and opponent attack counter in battlegrounds

### DIFF
--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.Update.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.Update.cs
@@ -177,7 +177,7 @@ namespace Hearthstone_Deck_Tracker.Windows
 		{
 			var inBattlegrounds = _game.CurrentGameMode == GameMode.Battlegrounds;
 
-			IconBoardAttackPlayer.Visibility = Config.Instance.HidePlayerAttackIcon || _game.IsInMenu || inBattlegrounds? Collapsed : Visible;
+			IconBoardAttackPlayer.Visibility = Config.Instance.HidePlayerAttackIcon || _game.IsInMenu || inBattlegrounds ? Collapsed : Visible;
 			IconBoardAttackOpponent.Visibility = Config.Instance.HideOpponentAttackIcon || _game.IsInMenu || inBattlegrounds ? Collapsed : Visible;
 
 			// do the calculation if at least one of the icons is visible

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.Update.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.Update.cs
@@ -175,8 +175,10 @@ namespace Hearthstone_Deck_Tracker.Windows
 
 		private void UpdateIcons()
 		{
-			IconBoardAttackPlayer.Visibility = Config.Instance.HidePlayerAttackIcon || _game.IsInMenu ? Collapsed : Visible;
-			IconBoardAttackOpponent.Visibility = Config.Instance.HideOpponentAttackIcon || _game.IsInMenu ? Collapsed : Visible;
+			var inBattlegrounds = _game.CurrentGameMode == GameMode.Battlegrounds;
+
+			IconBoardAttackPlayer.Visibility = Config.Instance.HidePlayerAttackIcon || _game.IsInMenu || inBattlegrounds? Collapsed : Visible;
+			IconBoardAttackOpponent.Visibility = Config.Instance.HideOpponentAttackIcon || _game.IsInMenu || inBattlegrounds ? Collapsed : Visible;
 
 			// do the calculation if at least one of the icons is visible
 			if (_game.SetupDone && (IconBoardAttackPlayer.Visibility == Visible || IconBoardAttackOpponent.Visibility == Visible))


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->
It's not terribly useful information in battlegrounds, especially now with Bob's Buddy.

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
