### PR TITLE
Fix issue 4079: ensure displayed lethal rates never exceed win/loss rates

### DIFF
--- a/Hearthstone Deck Tracker/Controls/Overlay/BobsBuddyPanel.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Overlay/BobsBuddyPanel.xaml.cs
@@ -201,27 +201,12 @@ namespace Hearthstone_Deck_Tracker.Controls.Overlay
 					lossRate += difference;
 				}
 			}
-			if(playerLethal + opponentLethal >= 1)
-			{
-				if(Math.Abs(1 - (playerLethal + opponentLethal)) > .00001)
-				{
-					var difference = 1 - (winRate + tieRate + lossRate);
-					if(playerLethal > opponentLethal)
-					{
-						playerLethal += difference;
-					}
-					else
-					{
-						opponentLethal += difference;
-					}
-				}
-			}
 
-			if(lethalWinStartedEqual)
+			if(lethalWinStartedEqual || playerLethal > winRate)
 			{
 				playerLethal = winRate;
 			}
-			if(lethalLossStartedEqual)
+			if(lethalLossStartedEqual || opponentLethal > lossRate)
 			{
 				opponentLethal = lossRate;
 			}
@@ -230,8 +215,8 @@ namespace Hearthstone_Deck_Tracker.Controls.Overlay
 			WinRateDisplay = string.Format("{0:0.#%}", winRate);
 			TieRateDisplay = string.Format("{0:0.#%}", tieRate);
 			LossRateDisplay = string.Format("{0:0.#%}", lossRate);
-			PlayerLethalDisplay = string.Format("{0:0.#%}", RoundAwayFromZeroOrOne(playerLethal));
-			OpponentLethalDisplay = string.Format("{0:0.#%}", RoundAwayFromZeroOrOne(opponentLethal));
+			PlayerLethalDisplay = string.Format("{0:0.#%}", playerLethal);
+			OpponentLethalDisplay = string.Format("{0:0.#%}", opponentLethal);
 
 			PlayerLethalOpacity = playerLethal > 0 ? 1 : 0.3;
 			OpponentLethalOpacity = opponentLethal > 0 ? 1 : 0.3;


### PR DESCRIPTION
**NB:** I don't have a Windows dev machine and so with great regret I submit this patch untested.  I hope it's simple enough for someone to just read and try.

To explain the issue, suppose the probabilities are:

* 0.04% to lose
* 0.04% to tie
* 99.92% to win
* 99.88% to win with lethal

The chance to win is unequal to the chance to win with lethal, so that code is irrelevant.  Then these get rounded to:

* 0.1% to lose
* 0.1% to tie
* 99.9% to win
* 99.9% to win with lethal

The code that ensures W + L + T = 1 runs and we get:

* 0.1% to lose
* 0.1% to tie
* 99.8% to win
* 99.9% to win with lethal

No other adjustments are made and this gets displayed, which looks ridiculous even if on some level it reflects reality.

The proposed fix is just to clamp the lethal percentages to the win/loss percentages.  As a bonus, the block that ensures displayed lethal never adds up to more than 1 can be discarded, since we already know displayed W + L can never be more than 1.

<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [ ] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

(I am happy to send an email to take care of the CLA if the PR is accepted.)