### PR TITLE
Add average damgage to bob's buddy

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -799,7 +799,16 @@ namespace Hearthstone_Deck_Tracker
 		public bool ShowBobsBuddyDuringShopping = false;
 
 		[DefaultValue(false)]
+		public bool AlwaysShowAverageDamage = false;
+
+		[DefaultValue(false)]
 		public bool SeenBobsBuddyInfo = false;
+
+		[DefaultValue(false)]
+		public bool SeenBobsBuddyAverageDamage = false;
+
+		[DefaultValue(false)]
+		public bool BobsBuddyAverageDamageInfoClosed = false;
 
 		[DefaultValue(false)]
 		public bool ShowCapturableOverlay = false;

--- a/Hearthstone Deck Tracker/Controls/Overlay/BobsBuddyPanel.xaml
+++ b/Hearthstone Deck Tracker/Controls/Overlay/BobsBuddyPanel.xaml
@@ -29,6 +29,22 @@
             <Setter Property="MinWidth" Value="60"/>
             <Setter Property="Margin" Value="5"/>
         </Style>
+        <Style x:Key="SpacerStyle" TargetType="Grid">
+            <Setter Property="Width" Value="8"/>
+            <Setter Property="Background">
+                <Setter.Value>
+                    <SolidColorBrush Color="Black" Opacity="0.01"/>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style x:Key="AverageDamageBorderStyle" TargetType="Border">
+            <Setter Property="Height" Value="56"/>
+            <Setter Property="MinWidth" Value="82"/>
+            <Setter Property="CornerRadius" Value="0 0 3 3"/>
+            <Setter Property="Background" Value="#141617"/>
+            <Setter Property="VerticalAlignment" Value="Top"/>
+        </Style>
+        
         <Style x:Key="SeparatorStyle" TargetType="Rectangle">
             <Setter Property="Fill" Value="#393D3F"/>
             <Setter Property="Width" Value="1"/>
@@ -48,6 +64,22 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
+        <Storyboard x:Key="StoryboardExpandAverageDamage">
+            <DoubleAnimation To="55" Duration="0:0:0.2" Storyboard.TargetName="AverageDamageGivenPanel" Storyboard.TargetProperty="Height" />
+            <DoubleAnimation To="55" Duration="0:0:0.2" Storyboard.TargetName="AverageDamageTakenPanel" Storyboard.TargetProperty="Height" />
+        </Storyboard>
+        <Storyboard x:Key="StoryboardCollapseAverageDamage">
+            <DoubleAnimation To="0" Duration="0:0:0.2" Storyboard.TargetName="AverageDamageGivenPanel" Storyboard.TargetProperty="Height" />
+            <DoubleAnimation To="0" Duration="0:0:0.2" Storyboard.TargetName="AverageDamageTakenPanel" Storyboard.TargetProperty="Height" />
+        </Storyboard>
+        <Storyboard x:Key="StoryboardExpandAverageDamageInstant">
+            <DoubleAnimation To="55" Duration="0:0:0" Storyboard.TargetName="AverageDamageGivenPanel" Storyboard.TargetProperty="Height" />
+            <DoubleAnimation To="55" Duration="0:0:0" Storyboard.TargetName="AverageDamageTakenPanel" Storyboard.TargetProperty="Height" />
+        </Storyboard>
+        <Storyboard x:Key="StoryboardCollapseAverageDamageInstant">
+            <DoubleAnimation To="0" Duration="0:0:0" Storyboard.TargetName="AverageDamageGivenPanel" Storyboard.TargetProperty="Height" />
+            <DoubleAnimation To="0" Duration="0:0:0" Storyboard.TargetName="AverageDamageTakenPanel" Storyboard.TargetProperty="Height" />
+        </Storyboard>
         <Storyboard x:Key="StoryboardExpand">
             <DoubleAnimation To="55" Duration="0:0:0.2" Storyboard.TargetName="ResultPanel" Storyboard.TargetProperty="Height" />
         </Storyboard>
@@ -55,66 +87,78 @@
             <DoubleAnimation To="0" Duration="0:0:0.2" Storyboard.TargetName="ResultPanel" Storyboard.TargetProperty="Height" />
         </Storyboard>
     </UserControl.Resources>
-    <StackPanel>
-        <StackPanel.Background>
-            <!-- To ensure consistent hover events -->
-            <SolidColorBrush Color="Black" Opacity="0.01"/>
-        </StackPanel.Background>
-        <Border Background="#141617" BorderThickness="0" BorderBrush="{x:Null}" CornerRadius="0 0 3 3">
+    <StackPanel x:Name="MainPanel" Orientation="Horizontal" ToolTipService.InitialShowDelay="2000" ToolTipService.ShowDuration="100000">
+        <Border x:Name="AverageDamageGivenPanel" Style="{StaticResource AverageDamageBorderStyle}" Margin="5, 0, 0, 5" Background="#141617" Height="0" MouseEnter="AverageDamageTakenPanel_MouseEnter" MouseLeave="AverageDamageTakenPanel_MouseLeave">
             <StackPanel>
-                <Border Name="ResultPanel" BorderThickness="0 0 0 1" BorderBrush="#393D3F" Height="0">
-                    <StackPanel Orientation="Horizontal">
-                        <StackPanel Style="{StaticResource ContainerStyle}" Opacity="{Binding PlayerLethalOpacity}">
-                            <Border Style="{StaticResource LabelContainerStyle}" >
-                                <TextBlock Text="{lex:LocTextUpper BobsBuddyPanel_Label_Lethal}" Style="{StaticResource LethalLabelTextStyle}" Foreground="#8AC66E" />
-                            </Border>
-                            <local:HearthstoneTextBlock Text="{Binding PlayerLethalDisplay}" FontSize="17" Opacity="0.85"
-                                VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding PercentagesVisibility}" />
-                        </StackPanel>
-                        <StackPanel Background="#23272A" Orientation="Horizontal">
-                            <StackPanel Style="{StaticResource ContainerStyle}">
-                                <Border Style="{StaticResource LabelContainerStyle}" >
-                                    <TextBlock Text="{lex:LocTextUpper BobsBuddyPanel_Label_Win}" Style="{StaticResource LabelTextStyle}" Foreground="#8AC66E" />
-                                </Border>
-                                <local:HearthstoneTextBlock Text="{Binding WinRateDisplay}" FontSize="21"
-                                    VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding PercentagesVisibility}" />
-                            </StackPanel>
-                            <Rectangle Style="{StaticResource SeparatorStyle}" />
-                            <StackPanel Style="{StaticResource ContainerStyle}">
-                                <Border Style="{StaticResource LabelContainerStyle}" >
-                                    <TextBlock Text="{lex:LocTextUpper BobsBuddyPanel_Label_Tie}" Style="{StaticResource LabelTextStyle}" Foreground="White" Opacity=".7" />
-                                </Border>
-                                <Grid>
-                                    <local:HearthstoneTextBlock Text="{Binding TieRateDisplay}" FontSize="21"
-                                        VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding PercentagesVisibility}" />
-                                    <controls:ProgressRing IsActive="True" Foreground="White" Width="20" Height="20" Visibility="{Binding SpinnerVisibility}"/>
-                                </Grid>
-                            </StackPanel>
-                            <Rectangle Style="{StaticResource SeparatorStyle}" />
-                            <StackPanel Style="{StaticResource ContainerStyle}">
-                                <Border Style="{StaticResource LabelContainerStyle}" >
-                                    <TextBlock Text="{lex:LocTextUpper BobsBuddyPanel_Label_Loss}" Style="{StaticResource LabelTextStyle}" Foreground="#C66E6E" />
-                                </Border>
-                                <local:HearthstoneTextBlock Text="{Binding LossRateDisplay}" FontSize="21"
-                                    VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding PercentagesVisibility}" />
-                            </StackPanel>
-                        </StackPanel>
-                        <StackPanel Style="{StaticResource ContainerStyle}" Opacity="{Binding OpponentLethalOpacity}">
-                            <Border Style="{StaticResource LabelContainerStyle}" >
-                                <TextBlock Text="{lex:LocTextUpper BobsBuddyPanel_Label_Lethal}" Style="{StaticResource LethalLabelTextStyle}" Foreground="#C66E6E" />
-                            </Border>
-                            <local:HearthstoneTextBlock Text="{Binding OpponentLethalDisplay}" FontSize="17" Opacity="0.85"
-                                VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding PercentagesVisibility}" />
-                        </StackPanel>
-                    </StackPanel>
+                <Border Style="{StaticResource LabelContainerStyle}" Margin="0, 5, 0, 0">
+                    <TextBlock Text= "{lex:Loc BobsBuddyPanel_Label_AVG}" Style="{StaticResource LethalLabelTextStyle}" Foreground="#8AC66E" Visibility="Visible" Opacity="{Binding PlayerAverageDamageOpacity}" />
                 </Border>
-                <Border BorderThickness="0" BorderBrush="{x:Null}" MouseDown="BottomBar_MouseDown" Cursor="Hand" MaxWidth="352">
-                    <Border.Background>
-                        <!-- For Cursor=Hand to work correctly -->
-                        <SolidColorBrush Color="Black" Opacity="0.001"/>
-                    </Border.Background>
-                    <Grid Margin="5">
-                        <TextBlock MinHeight="20" HorizontalAlignment="Center" VerticalAlignment="Center"
+                <local:HearthstoneTextBlock Text="{Binding AverageDamageGivenDisplay}" FontSize="17" Opacity="{Binding PlayerAverageDamageOpacity}"
+                            VerticalAlignment="Center" HorizontalAlignment="Center"/>
+            </StackPanel>
+        </Border>
+        <Grid Style="{StaticResource SpacerStyle}"/>
+        <StackPanel>
+            <StackPanel.Background>
+                <!-- To ensure consistent hover events -->
+                <SolidColorBrush Color="Black" Opacity="0.01"/>
+            </StackPanel.Background>
+            <Border Background="#141617" BorderThickness="0" BorderBrush="{x:Null}" CornerRadius="0 0 3 3">
+
+                <StackPanel>
+                    <Border Name="ResultPanel" BorderThickness="0 0 0 1" BorderBrush="#393D3F" Height="0">
+                        <StackPanel Orientation="Horizontal">
+                            <StackPanel Style="{StaticResource ContainerStyle}" Opacity="{Binding PlayerLethalOpacity}">
+                                <Border Style="{StaticResource LabelContainerStyle}" >
+                                    <TextBlock Text="{lex:LocTextUpper BobsBuddyPanel_Label_Lethal}" Style="{StaticResource LethalLabelTextStyle}" Foreground="#8AC66E" />
+                                </Border>
+                                <local:HearthstoneTextBlock Text="{Binding PlayerLethalDisplay}" FontSize="17" Opacity="0.85"
+                                VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding PercentagesVisibility}" />
+                            </StackPanel>
+                            <StackPanel Background="#23272A" Orientation="Horizontal">
+                                <StackPanel Style="{StaticResource ContainerStyle}">
+                                    <Border Style="{StaticResource LabelContainerStyle}" >
+                                        <TextBlock Text="{lex:LocTextUpper BobsBuddyPanel_Label_Win}" Style="{StaticResource LabelTextStyle}" Foreground="#8AC66E" />
+                                    </Border>
+                                    <local:HearthstoneTextBlock Text="{Binding WinRateDisplay}" FontSize="21"
+                                    VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding PercentagesVisibility}" />
+                                </StackPanel>
+                                <Rectangle Style="{StaticResource SeparatorStyle}" />
+                                <StackPanel Style="{StaticResource ContainerStyle}">
+                                    <Border Style="{StaticResource LabelContainerStyle}" >
+                                        <TextBlock Text="{lex:LocTextUpper BobsBuddyPanel_Label_Tie}" Style="{StaticResource LabelTextStyle}" Foreground="White" Opacity=".7" />
+                                    </Border>
+                                    <Grid>
+                                        <local:HearthstoneTextBlock Text="{Binding TieRateDisplay}" FontSize="21"
+                                        VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding PercentagesVisibility}" />
+                                        <controls:ProgressRing IsActive="True" Foreground="White" Width="20" Height="20" Visibility="{Binding SpinnerVisibility}"/>
+                                    </Grid>
+                                </StackPanel>
+                                <Rectangle Style="{StaticResource SeparatorStyle}" />
+                                <StackPanel Style="{StaticResource ContainerStyle}">
+                                    <Border Style="{StaticResource LabelContainerStyle}" >
+                                        <TextBlock Text="{lex:LocTextUpper BobsBuddyPanel_Label_Loss}" Style="{StaticResource LabelTextStyle}" Foreground="#C66E6E" />
+                                    </Border>
+                                    <local:HearthstoneTextBlock Text="{Binding LossRateDisplay}" FontSize="21"
+                                    VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding PercentagesVisibility}" />
+                                </StackPanel>
+                            </StackPanel>
+                            <StackPanel Style="{StaticResource ContainerStyle}" Opacity="{Binding OpponentLethalOpacity}">
+                                <Border Style="{StaticResource LabelContainerStyle}" >
+                                    <TextBlock Text="{lex:LocTextUpper BobsBuddyPanel_Label_Lethal}" Style="{StaticResource LethalLabelTextStyle}" Foreground="#C66E6E" />
+                                </Border>
+                                <local:HearthstoneTextBlock Text="{Binding OpponentLethalDisplay}" FontSize="17" Opacity="0.85"
+                                VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding PercentagesVisibility}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                    <Border BorderThickness="0" BorderBrush="{x:Null}" MouseDown="BottomBar_MouseDown" Cursor="Hand" MaxWidth="352">
+                        <Border.Background>
+                            <!-- For Cursor=Hand to work correctly -->
+                            <SolidColorBrush Color="Black" Opacity="0.001"/>
+                        </Border.Background>
+                        <Grid Margin="5">
+                            <TextBlock MinHeight="20" HorizontalAlignment="Center" VerticalAlignment="Center"
                                    Background="Transparent" Foreground="White" FontSize="14" Margin="25,0" TextWrapping="Wrap">
                                     <Rectangle Width="16" Height="16" Style="{StaticResource StatusBarIconStyle}" Visibility="{Binding WarningIconVisibility}" MouseDown="Settings_MouseDown" Margin="0,0,0,-2">
                                         <Rectangle.Fill>
@@ -122,43 +166,73 @@
                                         </Rectangle.Fill>
                                     </Rectangle>
                                    <Run Text="{Binding StatusMessage, Mode=OneWay}"/>
-                        </TextBlock>
-                        <Rectangle Width="12" Height="18" Style="{StaticResource StatusBarIconStyle}" HorizontalAlignment="Left" Visibility="{Binding SettingsVisibility}" MouseDown="Question_MouseDown">
-                            <Rectangle.Fill>
-                                <VisualBrush Visual="{StaticResource appbar_question}" />
-                            </Rectangle.Fill>
-                        </Rectangle>
-                        <Rectangle Width="20" Height="20" Style="{StaticResource StatusBarIconStyle}" HorizontalAlignment="Right" Visibility="{Binding SettingsVisibility}" MouseDown="Settings_MouseDown">
-                            <Rectangle.Fill>
-                                <VisualBrush Visual="{StaticResource appbar_settings}" />
-                            </Rectangle.Fill>
-                        </Rectangle>
-                    </Grid>
-                </Border>
-            </StackPanel>
-        </Border>
-        <Border Background="#23272A" BorderBrush="#141617" BorderThickness="1" CornerRadius="3" Margin="0,5,0,0" Visibility="{Binding InfoVisibility}" MaxWidth="352">
-            <Grid>
-                <StackPanel Margin="10">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{lex:Loc BobsBuddyPanel_Info_Title}" Foreground="White" FontSize="14" FontWeight="Bold"/>
-                        <Border Background="{DynamicResource AccentBaseColorBrush}" VerticalAlignment="Center" Margin="5,0,0,0" CornerRadius="3">
-                            <TextBlock Text="{lex:LocTextUpper Label_Beta}" Foreground="White" FontSize="12" FontWeight="Bold" Margin="4,1,4,2"/>
-                        </Border>
-                    </StackPanel>
-                    <TextBlock Foreground="White" FontSize="14" TextWrapping="Wrap">
+                            </TextBlock>
+                            <Rectangle Width="12" Height="18" Style="{StaticResource StatusBarIconStyle}" HorizontalAlignment="Left" Visibility="{Binding SettingsVisibility}" MouseDown="Question_MouseDown">
+                                <Rectangle.Fill>
+                                    <VisualBrush Visual="{StaticResource appbar_question}" />
+                                </Rectangle.Fill>
+                            </Rectangle>
+                            <Rectangle Width="20" Height="20" Style="{StaticResource StatusBarIconStyle}" HorizontalAlignment="Right" Visibility="{Binding SettingsVisibility}" MouseDown="Settings_MouseDown">
+                                <Rectangle.Fill>
+                                    <VisualBrush Visual="{StaticResource appbar_settings}" />
+                                </Rectangle.Fill>
+                            </Rectangle>
+                        </Grid>
+                    </Border>
+                </StackPanel>
+            </Border>
+
+            <Border Background="#23272A" BorderBrush="#141617" BorderThickness="1" CornerRadius="3" Margin="0,5,0,0" Visibility="{Binding InfoVisibility}" MaxWidth="352">
+                <Grid>
+                    <StackPanel Margin="10">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{lex:Loc BobsBuddyPanel_Info_Title}" Foreground="White" FontSize="14" FontWeight="Bold"/>
+                            <Border Background="{DynamicResource AccentBaseColorBrush}" VerticalAlignment="Center" Margin="5,0,0,0" CornerRadius="3">
+                                <TextBlock Text="{lex:LocTextUpper Label_Beta}" Foreground="White" FontSize="12" FontWeight="Bold" Margin="4,1,4,2"/>
+                            </Border>
+                        </StackPanel>
+                        <TextBlock Foreground="White" FontSize="14" TextWrapping="Wrap">
                         <Run Text="{lex:Loc BobsBuddyPanel_Info_Description}"/>
                         <Hyperlink Command="{Binding OpenUrl, Source={StaticResource GlobalCommands}}" CommandParameter="https://articles.hsreplay.net/2020/04/24/introducing-bobs-buddy/">
                             <Run Text="{lex:Loc BobsBuddyPanel_Info_Link_LearnMore}"/>
                         </Hyperlink>
-                    </TextBlock>
-                </StackPanel>
-                <Rectangle Width="14" Height="14" Style="{StaticResource StatusBarIconStyle}" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="8" MouseDown="Close_MouseDown">
-                    <Rectangle.Fill>
-                        <VisualBrush Visual="{StaticResource appbar_close_white}" />
-                    </Rectangle.Fill>
-                </Rectangle>
-            </Grid>
+                        </TextBlock>
+                    </StackPanel>
+                    <Rectangle Width="14" Height="14" Style="{StaticResource StatusBarIconStyle}" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="8" MouseDown="Close_MouseDown">
+                        <Rectangle.Fill>
+                            <VisualBrush Visual="{StaticResource appbar_close_white}" />
+                        </Rectangle.Fill>
+                    </Rectangle>
+                </Grid>
+            </Border>
+            <Border Background="#23272A" BorderBrush="#141617" BorderThickness="1" CornerRadius="3" Margin="0,5,0,0" Visibility="{Binding AverageDamageInfoVisibility}" MaxWidth="352">
+                <Grid>
+                    <StackPanel Margin="10">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{lex:Loc AverageDamage_Info_Title}" Foreground="White" FontSize="14" FontWeight="Bold"/>
+                        </StackPanel>
+                        <TextBlock Foreground="White" FontSize="14" TextWrapping="Wrap">
+                        <Run Text="{lex:Loc AverageDamage_Info_Description}"/>
+                        </TextBlock>
+                    </StackPanel>
+                    <Rectangle Width="14" Height="14" Style="{StaticResource StatusBarIconStyle}" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="8" MouseDown="CloseAverageDamageInfo_MouseDown" Visibility="{Binding CloseAverageDamageInfoVisibility}">
+                        <Rectangle.Fill>
+                            <VisualBrush Visual="{StaticResource appbar_close_white}" />
+                        </Rectangle.Fill>
+                    </Rectangle>
+                </Grid>
+            </Border>
+        </StackPanel>
+
+        <Grid Style="{StaticResource SpacerStyle}"/>
+            <Border x:Name="AverageDamageTakenPanel" Style="{StaticResource AverageDamageBorderStyle}" Margin="5, 0, 0, 5" Background="#141617" Height="0" MouseEnter="AverageDamageTakenPanel_MouseEnter" MouseLeave="AverageDamageTakenPanel_MouseLeave">
+            <StackPanel>
+                <Border Style="{StaticResource LabelContainerStyle}" Margin="0, 5, 0, 0">
+                    <TextBlock Text="{lex:Loc BobsBuddyPanel_Label_AVG}" Style="{StaticResource LethalLabelTextStyle}" Foreground="#C66E6E" Opacity="{Binding OpponentAverageDamageOpacity}"/>
+                </Border>
+                <local:HearthstoneTextBlock Text="{Binding AverageDamageTakenDisplay}" FontSize="17" Opacity="{Binding OpponentAverageDamageOpacity}"
+                                    VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="Visible"/>
+            </StackPanel>
         </Border>
     </StackPanel>
 </UserControl>

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayBattlegrounds.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayBattlegrounds.xaml
@@ -34,6 +34,10 @@
                           HorizontalAlignment="Left"
                           VerticalAlignment="Top" Checked="CheckboxShowResultsDuringShopping_Checked"
                           Unchecked="CheckboxShowResultsDuringShopping_Unchecked" Margin="0,5,0,0" />
+                <CheckBox x:Name="CheckboxAlwaysShowAverageDamage" Content="{lex:Loc Options_Overlay_Battlegrounds_CheckBox_ShowAverageDamage}"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Top" Checked="CheckboxAlwaysShowAverageDamage_Checked"
+                          Unchecked="CheckboxAlwaysShowAverageDamage_Unchecked" Margin="0,5,0,0" />
             </StackPanel>
         </GroupBox>
         <Button x:Name="OverlayHelpButton"

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayBattlegrounds.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayBattlegrounds.xaml.cs
@@ -35,6 +35,10 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 
 			CheckboxShowResultsDuringShopping.IsChecked = Config.Instance.ShowBobsBuddyDuringShopping;
 			CheckboxShowResultsDuringShopping.IsEnabled = Config.Instance.RunBobsBuddy;
+
+			CheckboxAlwaysShowAverageDamage.IsChecked = Config.Instance.AlwaysShowAverageDamage;
+			CheckboxAlwaysShowAverageDamage.IsEnabled = Config.Instance.RunBobsBuddy;
+
 			_initialized = true;
 		}
 
@@ -58,6 +62,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 			TextBobsBuddyDisabled.Visibility = enabled ? Visibility.Collapsed : Visibility.Visible;
 			CheckboxShowResultsDuringCombat.IsEnabled = enabled && Config.Instance.RunBobsBuddy;
 			CheckboxShowResultsDuringShopping.IsEnabled = enabled && Config.Instance.RunBobsBuddy;
+			CheckboxAlwaysShowAverageDamage.IsEnabled = enabled && Config.Instance.RunBobsBuddy;
 		}
 
 		private void SaveConfig(bool updateOverlay)
@@ -162,6 +167,24 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 			if(!_initialized)
 				return;
 			Config.Instance.ShowBobsBuddyDuringShopping = false;
+			SaveConfig(true);
+		}
+
+		private void CheckboxAlwaysShowAverageDamage_Checked(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+			Config.Instance.AlwaysShowAverageDamage = true;
+			Core.Overlay.BobsBuddyDisplay.AttemptToExpandAverageDamagePanels(false, false);
+			SaveConfig(true);
+		}
+
+		private void CheckboxAlwaysShowAverageDamage_Unchecked(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+			Config.Instance.AlwaysShowAverageDamage = false;
+			Core.Overlay.BobsBuddyDisplay.ShowAverageDamagesPanels(false);
 			SaveConfig(true);
 		}
 

--- a/Hearthstone Deck Tracker/Hearthstone/BattlegroundsBoardState.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/BattlegroundsBoardState.cs
@@ -1,9 +1,6 @@
 ﻿using Hearthstone_Deck_Tracker.Utility.Logging;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Hearthstone_Deck_Tracker.Hearthstone
 {

--- a/Hearthstone Deck Tracker/Windows/DebugWindow.xaml
+++ b/Hearthstone Deck Tracker/Windows/DebugWindow.xaml
@@ -2,11 +2,14 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:system="clr-namespace:System;assembly=mscorlib"
+        xmlns:overlay="clr-namespace:Hearthstone_Deck_Tracker.Controls.Overlay"
         Title="DebugWindow" Height="300" Width="300">
     <Grid>
         <TabControl Name="TabControlDebug">
             <TabItem Header="Cards">
                 <DockPanel Margin="0,2">
+                    <overlay:BobsBuddyPanel Margin="50" x:Name="BBPanel"/>
+
                     <WrapPanel DockPanel.Dock="Top">
                         <Button Name="ExpandAllBtn" Click="ExpandAllBtn_Click" Margin="2,0">Expand All</Button>
                         <Button Name="CollapseAllBtn" Click="CollapseAllBtn_Click" Margin="2,0">Collapse All</Button>

--- a/Hearthstone Deck Tracker/Windows/DebugWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/DebugWindow.xaml.cs
@@ -33,6 +33,7 @@ namespace Hearthstone_Deck_Tracker.Windows
 			InitializeComponent();
 			_update = true;
 			Closing += (sender, args) => _update = false;
+			BBPanel.ShowResults(true);
 			Update();
 		}
 


### PR DESCRIPTION
Pass damage possibilites to the bb overlay

Add tooltip to average damage

Pass last combat damage dealt to bb panel

Add average damage tooltip messaging dependant on state

Change tooltip display based on state and possible results

Update tooltip offset when results are shown

Cast possibilities count

Link average damage opacity to damage possibilities

Note: this is temporary as we still haven't made the policy decision as to what the left/ right panels will show

Change soft label opacity to a classwide const

Default lethal and average damage to softly opaque

Smooth average damage panel transition

Add setting for showing average damage

Add extra casting to betterThanPortion

Change opponent av damage to red

Tooltip centering fix attempt

Add BB panel to debug window

Fix tooltip centering within xaml

Fix some formatting issues, no code changes

Fix horizontal offset for average damage tooltip

Split average damage between taken and given

Add setting to only show Av damage on mouse hover

Have average damage auto appear with settings change

Make tooltip always display 80% DMG

Make av damage panels appear immediatley upon hover

Have default behavior be to show av damage on hover

Make config changes immediately affect the panel

Add two second delay before showing tooltip

Add space between lower and upper average damage bounds

Restore second level tooltip

Always have second tooltip be Middle 80% percentile of damage

Remove whitespace around dash

Add mouseover bridge between main panel and av damage

Reduce time for tooltip to appear

Move secondary tooltip to appear over full panel

Add 2 second initial show delay and have it no disappear

Adjust and fix tooltip offset

Don't show av damage if main panel isn't expanded

Remove old tooltip code

Have secondary tooltip immidealty open on panel hover

Add second tooltip to appear under right panel

Remove small tooltip message

Add new bigger average damage info

Make second tooltip show up on hover unless has been closed

Don't show close button if has been closed

Show and hide panel based on mouse enter/leave

Show av damage when never seen before and get unusual result

Show 0 instead of N/A if player/opponent can't deal damage

Make the close button's visibility its own property

Make info collapse not fully hide

Remove old file from csproj

Remove unecessary usings

Properly delay for showing average damage

Cleanup files

Cleanup code

Simplify average damage

Reset av damage text at sim start

Make av damage panels transitions smoother

Add localization to average damage

Separate hover spacers into their own style

Move Avg damage styling to surrounding border

<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [ ] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [ ] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
