### PR TITLE
Fix download card image repeatedly when file exists

### DIFF
--- a/Hearthstone Deck Tracker/Utility/Assets/AssetDownloader.cs
+++ b/Hearthstone Deck Tracker/Utility/Assets/AssetDownloader.cs
@@ -256,7 +256,7 @@ namespace Hearthstone_Deck_Tracker.Utility.Assets
 
 		private string InProgressPathFor(string filename) => Path.Combine(_inProgressDestination, filename);
 
-		public IEnumerable<string> GetCurrentlyStoredFileNames() => GetStoredImagesContent().Select(Path.GetFileNameWithoutExtension);
+		public IEnumerable<string> GetCurrentlyStoredFileNames() => GetStoredImagesContent().Select(Path.GetFileName);
 
 		private List<string> GetStoredImagesContent()
 		{


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/f7b70235276a3bec055795e06801242ece1d7b9b/Hearthstone%20Deck%20Tracker/Utility/Assets/AssetDownloader.cs#L230
```C#
public bool HasAsset(T obj)
		{
			if(obj == null)
				return false;
			var filename = _getFilename(obj);
			return _succesfullyDownloadedImages.Contains(filename);
		}
```
The filename you get from `var filename = _getFilename(obj);` contains file extension, why you get files without extension. It make the HDT always download the image file again and again.
