### PR TITLE
Added Ysera the Dreamer Dream card tracking

### DIFF
--- a/Hearthstone Deck Tracker/LogReader/Handlers/PowerHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/PowerHandler.cs
@@ -640,6 +640,13 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 								else
 									gameState.GameHandler.HandleOpponentLibramReduction(2);
 								break;
+							case Collectible.Neutral.YseraTheDreamerCore:
+								AddKnownCardId(gameState, NonCollectible.DreamCards.NightmareExpert1);
+								AddKnownCardId(gameState, NonCollectible.DreamCards.Dream);
+								AddKnownCardId(gameState, NonCollectible.DreamCards.LaughingSister);
+								AddKnownCardId(gameState, NonCollectible.DreamCards.YseraAwakens);
+								AddKnownCardId(gameState, NonCollectible.DreamCards.EmeraldDrake);
+								break;
 							default:
 								if(playerEntity.Value != null && playerEntity.Value.GetTag(GameTag.CURRENT_PLAYER) == 1
 									&& !gameState.PlayerUsedHeroPower


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

Adds tracking for the dream cards which are given from Ysera the Dreamer's Battlecry.