### PR TITLE
update attack damage when replacement hero has weapon #4165

### DIFF
--- a/HDTTests/BoardDamage/BoardHeroTest.cs
+++ b/HDTTests/BoardDamage/BoardHeroTest.cs
@@ -12,7 +12,7 @@ namespace HDTTests.BoardDamage
 		[TestInitialize]
 		public void Setup()
 		{
-			_hero = new EntityBuilder("HERO_01", 0, 30);
+			_hero = new EntityBuilder("HERO_01", 0, 30).Hero();
 			_weapon = new EntityBuilder("DS1_188", 5, 0);
 			_weapon.Weapon().Durability(2);
 		}
@@ -49,6 +49,13 @@ namespace HDTTests.BoardDamage
 		public void Include_IfActive()
 		{
 			var hero = new BoardHero(_hero.ToEntity(), null, true);
+			Assert.IsTrue(hero.Include);
+		}
+
+		[TestMethod]
+		public void Include_IfActive_AndZeroTurnsInPlay()
+		{
+			var hero = new BoardHero(_hero.ZeroTurnsInPlay().ToEntity(), null, true);
 			Assert.IsTrue(hero.Include);
 		}
 

--- a/Hearthstone Deck Tracker/Utility/BoardDamage/BoardCard.cs
+++ b/Hearthstone Deck Tracker/Utility/BoardDamage/BoardCard.cs
@@ -32,7 +32,7 @@ namespace Hearthstone_Deck_Tracker.Utility.BoardDamage
 			_armor = e.GetTag(ARMOR);
 			_durability = e.GetTag(DURABILITY);
 			_damageTaken = e.GetTag(DAMAGE);
-			Exhausted = e.GetTag(EXHAUSTED) == 1 || e.GetTag(NUM_TURNS_IN_PLAY) == 0;
+			Exhausted = e.GetTag(EXHAUSTED) == 1 || (e.GetTag(NUM_TURNS_IN_PLAY) == 0 && !e.IsHero);
 			_cantAttack = e.GetTag(CANT_ATTACK) == 1;
 			_frozen = e.GetTag(FROZEN) == 1;
 			Charge = e.GetTag(CHARGE) == 1;


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

I updated `BoardCard` to not mark a hero played this turn as `Exhausted`. This fix counts Jaraxuus's weapon damage immediately after he's played.

Fixes #4165 
