### PR TITLE
API secrets played from deck handling

### DIFF
--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -1105,7 +1105,20 @@ namespace Hearthstone_Deck_Tracker
 			}
 			Core.UpdatePlayerCards();
 			if(card != null)
-				GameEvents.OnPlayerPlay.Execute(card);
+			{
+				switch(fromZone)
+				{
+					case Zone.DECK:
+						GameEvents.OnPlayerDeckToPlay.Execute(card);
+						break;
+					case Zone.HAND:
+						GameEvents.OnPlayerPlay.Execute(card);
+						break;
+					default:
+						break;
+
+				}
+			}				
 		}
 
 		public void HandlePlayerHandDiscard(Entity entity, string cardId, int turn)
@@ -1419,7 +1432,17 @@ namespace Hearthstone_Deck_Tracker
 				return;
 			_game.SecretsManager.NewSecret(entity);
 			if(card != null)
-				GameEvents.OnOpponentPlay.Execute(card);
+			{
+				switch(fromZone)
+				{
+					case Zone.DECK:
+						GameEvents.OnOpponentDeckToPlay.Execute(card);
+						break;
+					case Zone.HAND:
+						GameEvents.OnOpponentPlay.Execute(card);
+						break;
+				}
+			}
 		}
 
 		public void HandleOpponentPlayToHand(Entity entity, string? cardId, int turn, int id)


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

As per [Multicaster view #12](https://github.com/batstyx/Graveyard/issues/12), the HDT API is currently reporting secrets played from deck by the cards below as `OnPlayerPlay` rather than `OnPlayerDeckToPlay`

**Affected Cards**
- Mad Scientist 
- Inconspicuous Rider
- Sword of the Fallen
- Bellringer Sentry
- Phase Stalker

Have modified both player and opponent code for consistency although I suspect the opponent code is never reached.