### PR TITLE
[Battlegrounds] Added a way to show available minions

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -858,6 +858,9 @@ namespace Hearthstone_Deck_Tracker
 		public bool ShowSessionRecapMinionsBanned = true;
 
 		[DefaultValue(true)]
+		public bool ShowSessionRecapMinionsAvailable = true;
+
+		[DefaultValue(true)]
 		public bool ShowSessionRecapStartCurrentMMR = true;
 
 		[DefaultValue(true)]

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSession.xaml
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSession.xaml
@@ -35,36 +35,27 @@
                 <StackPanel
                     Orientation="Vertical"
                 >
-                    <StackPanel Background="#2E3235" Visibility="{Binding BgBannedTribesSectionVisibility}">
+                    <StackPanel Background="#2E3235" Visibility="{Binding BgAvailableTribesSectionVisibility}">
                         <Border BorderBrush="#4A5256" BorderThickness="0,0,0,1" Background="#1C2022">
-                            <hearthstoneDeckTracker:HearthstoneTextBlock Text="{lex:Loc Battlegrounds_Session_Header_Label_Minions_Banned}" FontSize="13" HorizontalAlignment="Center" Margin="0,6"/>
+                            <hearthstoneDeckTracker:HearthstoneTextBlock Text="{lex:Loc Battlegrounds_Session_Header_Label_Minions_Available}" FontSize="13" HorizontalAlignment="Center" Margin="0,6"/>
                         </Border>
-                        <StackPanel Name="BgBannedTribes" Orientation="Horizontal" Margin="8,8,8,4" HorizontalAlignment="Center" Height="58">
-                            <local:BattlegroundsTribe
-                                Tribe="{Binding BannedTribe1, FallbackValue=PET}"
-                                Visibility="{Binding BannedTribesVisibility}"
-                            />
-                            <local:BattlegroundsTribe
-                                Tribe="{Binding BannedTribe2, FallbackValue=PET}"
-                                Margin="8,0,0,0"
-                                Visibility="{Binding BannedTribesVisibility}"
-                            />
-                            <local:BattlegroundsTribe
-                                Tribe="{Binding BannedTribe3, FallbackValue=PET}"
-                                Margin="8,0,0,0"
-                                Visibility="{Binding BannedTribesVisibility}"
-                            />
-                            <local:BattlegroundsTribe
-                                Tribe="{Binding BannedTribe4, FallbackValue=PET}"
-                                Margin="8,0,0,0"
-                                Visibility="{Binding BannedTribesVisibility}"
-                            />
-                            <local:BattlegroundsTribe
-                                Tribe="{Binding BannedTribe5, FallbackValue=PET}"
-                                Margin="8,0,0,0"
-                                Visibility="{Binding BannedTribesVisibility}"
-                            />
-                            <TextBlock
+                        <ItemsControl Name="BgAvailableTribes" ItemsSource="{Binding AvailableRaces}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <local:BattlegroundsTribe
+                                        Tribe="{Binding, FallbackValue=PET}"
+                                        Visibility="{Binding AvailableTribesVisibility}"
+                                        Available="true"
+                                    />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Horizontal" Margin="8,8,8,4" HorizontalAlignment="Center" Height="58"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
+                         <TextBlock
                                 x:Name="BgTribeWaiting"
                                 Text="{lex:Loc Battlegrounds_Session_Text_WaitingNextGame}"
                                 Foreground="#FFFFFF"
@@ -73,10 +64,42 @@
                                 TextAlignment="Center"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center"
-                                Visibility="{Binding BannedTribesMsgVisibility, FallbackValue=Collapsed}"
+                                Visibility="{Binding TribesMsgVisibility, FallbackValue=Collapsed}"
                                 Margin="0 0 0 5"
                             />
-                        </StackPanel>
+                    </StackPanel>
+                    <StackPanel Background="#2E3235" Visibility="{Binding BgBannedTribesSectionVisibility}">
+                        <Border BorderBrush="#4A5256" BorderThickness="0,0,0,1" Background="#1C2022">
+                            <hearthstoneDeckTracker:HearthstoneTextBlock Text="{lex:Loc Battlegrounds_Session_Header_Label_Minions_Banned}" FontSize="13" HorizontalAlignment="Center" Margin="0,6"/>
+                        </Border>
+                        <ItemsControl Name="BgBannedTribes" ItemsSource="{Binding UnavailableRaces}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <local:BattlegroundsTribe
+                                        Tribe="{Binding, FallbackValue=PET}"
+                                        Visibility="{Binding BannedTribesVisibility}"
+                                        Available="false"
+                                    />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Horizontal" Margin="8,8,8,4" HorizontalAlignment="Center" Height="58"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
+                         <TextBlock
+                                x:Name="BgTribeWaiting"
+                                Text="{lex:Loc Battlegrounds_Session_Text_WaitingNextGame}"
+                                Foreground="#FFFFFF"
+                                Opacity=".5"
+                                TextWrapping="WrapWithOverflow"
+                                TextAlignment="Center"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Visibility="{Binding TribesMsgVisibility, FallbackValue=Collapsed}"
+                                Margin="0 0 0 5"
+                            />
                     </StackPanel>
                     <StackPanel Background="#2E3235" Visibility="{Binding BgStartCurrentMMRSectionVisibility}">
                         <Border BorderBrush="#4A5256" BorderThickness="0,1,0,0" Visibility="{Binding ElementName=BgBannedTribesSection, Path=Visibility}"/>

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionViewModel.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionViewModel.xaml.cs
@@ -18,6 +18,8 @@ namespace Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds.Session
 		private readonly Lazy<BattlegroundsDb> _db = new();
 
 		public ObservableCollection<BattlegroundsGameViewModel> SessionGames { get; set; } = new();
+		public ObservableCollection<Rase> AvailableRaces { get; set; } = new();
+		public ObservableCollection<Race> UnavailableRaces { get; set; } = new();
 
 		public void OnGameEnd()
 		{
@@ -49,6 +51,10 @@ namespace Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds.Session
 
 		public void UpdateSectionsVisibilities()
 		{
+			BgAvailableTribesSectionVisibility = Config.Instance.ShowSessionRecapMinionsAvailable
+				? Visibility.Visible
+				: Visibility.Collapsed;
+
 			BgBannedTribesSectionVisibility = Config.Instance.ShowSessionRecapMinionsBanned
 				? Visibility.Visible
 				: Visibility.Collapsed;
@@ -68,29 +74,31 @@ namespace Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds.Session
 		{
 			var allRaces = _db.Value.Races;
 			var availableRaces = BattlegroundsUtils.GetAvailableRaces(Core.Game.CurrentGameStats?.GameId) ?? allRaces;
-			var unavailableRaces = allRaces.Where(x => !availableRaces.Contains(x) && x != Race.INVALID && x != Race.ALL)
-				.OrderBy(t => HearthDbConverter.RaceConverter(t) ?? "")
-				.ToList();
+			var unavailableRaces = allRaces.Where(x => !availableRaces.Contains(x) && x != Race.INVALID && x != Race.ALL);
+
+			AvailableRaces.Clear();
+			foreach (var item in availableRaces.OrderBy(t => HearthDbConverter.RaceConverter(t) ?? "").ToList()) {
+				AvailableRaces.Add(item);
+			}
+
+			UnavailableRaces.Clear();
+			foreach (var item in unavailableRaces.OrderBy(t => HearthDbConverter.RaceConverter(t) ?? "").ToList()) {
+				UnavailableRaces.Add(item);
+			}
 
 			var bannedTribesUpdated = unavailableRaces.Count() >= 5;
-			if(bannedTribesUpdated)
-			{
-				BannedTribe1 = unavailableRaces[0];
-				BannedTribe2 = unavailableRaces[1];
-				BannedTribe3 = unavailableRaces[2];
-				BannedTribe4 = unavailableRaces[3];
-				BannedTribe5 = unavailableRaces[4];
-			}
 
 			if(Core.Game.CurrentMode == Mode.GAMEPLAY && bannedTribesUpdated)
 			{
 				BannedTribesVisibility = Visibility.Visible;
-				BannedTribesMsgVisibility = Visibility.Collapsed;
+				AvailableTribesVisibility = Visibility.Visible;
+				TribesMsgVisibility = Visibility.Collapsed;
 			}
 			else
 			{
 				BannedTribesVisibility = Visibility.Collapsed;
-				BannedTribesMsgVisibility = Visibility.Visible;
+				AvailableTribesVisibility = Visibility.Collapsed;
+				TribesMsgVisibility = Visibility.Visible;
 			}
 		}
 
@@ -218,61 +226,6 @@ namespace Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds.Session
 			}
 		}
 
-		private Race _bannedTribe1;
-		public Race BannedTribe1
-		{
-			get => _bannedTribe1;
-			set
-			{
-				_bannedTribe1 = value;
-				OnPropertyChanged();
-			}
-		}
-
-		private Race _bannedTribe2;
-		public Race BannedTribe2
-		{
-			get => _bannedTribe2;
-			set
-			{
-				_bannedTribe2 = value;
-				OnPropertyChanged();
-			}
-		}
-
-		private Race _bannedTribe3;
-		public Race BannedTribe3
-		{
-			get => _bannedTribe3;
-			set
-			{
-				_bannedTribe3 = value;
-				OnPropertyChanged();
-			}
-		}
-
-		private Race _bannedTribe4;
-		public Race BannedTribe4
-		{
-			get => _bannedTribe4;
-			set
-			{
-				_bannedTribe4 = value;
-				OnPropertyChanged();
-			}
-		}
-
-		private Race _bannedTribe5;
-		public Race BannedTribe5
-		{
-			get => _bannedTribe5;
-			set
-			{
-				_bannedTribe5 = value;
-				OnPropertyChanged();
-			}
-		}
-
 		private Visibility _bannedTribesVisibility;
 		public Visibility BannedTribesVisibility
 		{
@@ -284,13 +237,24 @@ namespace Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds.Session
 			}
 		}
 
-		private Visibility _bannedTribesMsgVisibility;
-		public Visibility BannedTribesMsgVisibility
+		private Visibility _availableTribesVisibility;
+		public Visibility AvailableTribesVisibility
 		{
-			get => _bannedTribesMsgVisibility;
+			get => _availableTribesVisibility;
 			set
 			{
-				_bannedTribesMsgVisibility = value;
+				_availableTribesVisibility = value;
+				OnPropertyChanged();
+			}
+		}
+
+		private Visibility _TribesMsgVisibility;
+		public Visibility TribesMsgVisibility
+		{
+			get => _TribesMsgVisibility;
+			set
+			{
+				_TribesMsgVisibility = value;
 				OnPropertyChanged();
 			}
 		}
@@ -324,6 +288,17 @@ namespace Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds.Session
 			set
 			{
 				_bgBannedTribesSectionVisibility = value;
+				OnPropertyChanged();
+			}
+		}
+
+		private Visibility _bgAvailableTribesSectionVisibility;
+		public Visibility BgAvailableTribesSectionVisibility
+		{
+			get => _bgAvailableTribesSectionVisibility;
+			set
+			{
+				_bgAvailableTribesSectionVisibility = value;
 				OnPropertyChanged();
 			}
 		}

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsTribe.xaml
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsTribe.xaml
@@ -8,7 +8,7 @@
              mc:Ignorable="d" >
     <StackPanel Orientation="Vertical">
         <Canvas Width="38" Height="38">
-            <Border BorderBrush="#D44040" BorderThickness="2" CornerRadius="36">
+            <Border BorderBrush="{Binding Color}" BorderThickness="2" CornerRadius="36">
                 <Ellipse Height="34" Width="34">
                     <Ellipse.Fill>
                         <ImageBrush
@@ -27,6 +27,7 @@
                 Canvas.Left="16"
                 Canvas.Top="15"
                 Source="/HearthstoneDeckTracker;component/Resources/tribes-x.png"
+                Visibility="!{Binding Available}"
             />
         </Canvas>
         <StackPanel Height="16" Margin="0,2,0,0" Orientation="Vertical">

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsTribe.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsTribe.xaml.cs
@@ -71,6 +71,36 @@ namespace Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds
 			}
 		}
 
+		private string _color = "#D44040";
+		public string Color =
+		{
+			get => _color;
+			set
+			{
+				_color = value;
+				OnPropertyChanged;
+			}
+		}
+
+		private bool _available = false;
+		public bool Available
+		{
+			get => _available;
+			set
+			{
+				_available = value;
+				if (_available)
+				{
+					_color = "#00A806";
+				}
+				else
+				{
+					_color = "#D44040";
+				}
+				OnPropertyChanged();
+			}
+		}
+
 		private void OnTribeChanged()
 		{
 			TribeName = HearthDbConverter.RaceConverter(Tribe) ?? "";

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayBattlegrounds.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayBattlegrounds.xaml.cs
@@ -89,6 +89,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 			CheckboxAlwaysShowAverageDamage.IsEnabled = Config.Instance.RunBobsBuddy;
 
 			CheckboxShowSessionRecap.IsChecked = Config.Instance.ShowSessionRecap;
+			CheckboxShowMinionsAvailable.IsChecked = Config.Instance.ShowSessionRecapMinionsAvailable;
 			CheckboxShowMinionsBanned.IsChecked = Config.Instance.ShowSessionRecapMinionsBanned;
 			CheckboxShowStartCurrentMMR.IsChecked = Config.Instance.ShowSessionRecapStartCurrentMMR;
 			CheckboxShowLatestGames.IsChecked = Config.Instance.ShowSessionRecapLatestGames;
@@ -351,11 +352,13 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 			Config.Instance.ShowSessionRecap = true;
 
 			if(
+				!Config.Instance.ShowSessionRecapMinionsAvailable &&
 				!Config.Instance.ShowSessionRecapMinionsBanned &&
 				!Config.Instance.ShowSessionRecapStartCurrentMMR &&
 				!Config.Instance.ShowSessionRecapLatestGames
 			)
 			{
+				CheckboxShowMinionsAvailable.IsChecked = true;
 				CheckboxShowMinionsBanned.IsChecked = true;
 				CheckboxShowStartCurrentMMR.IsChecked = true;
 				CheckboxShowLatestGames.IsChecked = true;
@@ -396,6 +399,33 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 			SaveConfig(true);
 			if (!Core.Game.IsBattlegroundsMatch)
 				Core.Overlay.ShowBattlegroundsSession(false, true);
+		}
+
+		private void CheckboxShowMinionsAvailable_Checked(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+			Config.Instance.ShowSessionRecapMinionsAvailable = true;
+			SaveConfig(true);
+			Core.Game.BattlegroundsSessionViewModel.UpdateSectionsVisibilities();
+		}
+
+		private void CheckboxShowMinionsAvailable_Unchecked(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+			Config.Instance.ShowSessionRecapMinionsAvailable = false;
+			if(
+				!Config.Instance.ShowSessionRecapStartCurrentMMR &&
+				!Config.Instance.ShowSessionRecapLatestGames
+			)
+			{
+				CheckboxShowSessionRecap.IsChecked = false;
+				CheckboxShowExternalWindow.IsChecked = false;
+			}
+
+			SaveConfig(true);
+			Core.Game.BattlegroundsSessionViewModel.UpdateSectionsVisibilities();
 		}
 
 		private void CheckboxShowMinionsBanned_Checked(object sender, RoutedEventArgs e)
@@ -440,6 +470,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 				return;
 			Config.Instance.ShowSessionRecapStartCurrentMMR = false;
 			if(
+				!Config.Instance.ShowSessionRecapMinionsAvailable &&
 				!Config.Instance.ShowSessionRecapMinionsBanned &&
 				!Config.Instance.ShowSessionRecapLatestGames
 			)
@@ -467,6 +498,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 				return;
 			Config.Instance.ShowSessionRecapLatestGames = false;
 			if(
+				!Config.Instance.ShowSessionRecapMinionsAvailable &&
 				!Config.Instance.ShowSessionRecapMinionsBanned &&
 				!Config.Instance.ShowSessionRecapStartCurrentMMR
 			)
@@ -487,11 +519,13 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 			Core.Windows.BattlegroundsSessionWindow.Activate();
 			Config.Instance.BattlegroundsSessionRecapWindowOnStart = true;
 			if(
+				!Config.Instance.ShowSessionRecapMinionsAvailable &&
 				!Config.Instance.ShowSessionRecapMinionsBanned &&
 				!Config.Instance.ShowSessionRecapStartCurrentMMR &&
 				!Config.Instance.ShowSessionRecapLatestGames
 			)
 			{
+				CheckboxShowMinionsAvailable.IsChecked = true;
 				CheckboxShowMinionsBanned.IsChecked = true;
 				CheckboxShowStartCurrentMMR.IsChecked = true;
 				CheckboxShowLatestGames.IsChecked = true;

--- a/Hearthstone Deck Tracker/Utility/ValueMoments/Actions/Action/BattlegroundsSettings.cs
+++ b/Hearthstone Deck Tracker/Utility/ValueMoments/Actions/Action/BattlegroundsSettings.cs
@@ -29,6 +29,9 @@ namespace Hearthstone_Deck_Tracker.Utility.ValueMoments.Actions.Action
 		[JsonProperty("session_recap_between_games")]
 		public bool SessionRecapBetweenGames { get => Config.Instance.ShowSessionRecapBetweenGames; }
 
+		[JsonProperty("minions_available")]
+		public bool MinionsBanned { get => Config.Instance.ShowSessionRecapMinionsAvailable; }
+		
 		[JsonProperty("minions_banned")]
 		public bool MinionsBanned { get => Config.Instance.ShowSessionRecapMinionsBanned; }
 


### PR DESCRIPTION
Now that there are the same number of minions in the game that are banned as there are available, it makes sense for users to be able to choose which type of minions to show on the overlay.

I don't think I have the tools to build and test these changes unfortunately so maintainers may need to edit

<!--- Please read the Contribution Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [ yes ] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [ working on it ] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
