### PR TITLE
Fix Twist C'Thun

### DIFF
--- a/Hearthstone Deck Tracker/Utility/WotogCounterHelper.cs
+++ b/Hearthstone Deck Tracker/Utility/WotogCounterHelper.cs
@@ -26,11 +26,6 @@ namespace Hearthstone_Deck_Tracker.Utility
 			get
 			{
 				var cthun = PlayerCthun;
-				//Log.Debug($"Player C'Thun {cthun?.Attack}/{cthun?.Health}");
-				//Log.Debug($"Player C'Thun Proxy {PlayerCthunProxy?.Attack}/{PlayerCthunProxy?.Health}");
-				//var player = Core.Game.PlayerEntity;
-				//var seenCThun = player?.HasTag(SEEN_CTHUN) ?? false;
-				//Log.Debug($"Player C'Thun Seen: {seenCThun}");
 				return cthun != null;
 			}
 		}
@@ -40,11 +35,6 @@ namespace Hearthstone_Deck_Tracker.Utility
 			get
 			{
 				var cthun = OpponentCthun;
-				//Log.Debug($"Opponent C'Thun {cthun?.Attack}/{cthun?.Health}");
-				//Log.Debug($"Opponent C'Thun Proxy {OpponentCthunProxy?.Attack}/{OpponentCthunProxy?.Health}");
-				//var player = Core.Game.OpponentEntity;
-				//var seenCThun = player?.HasTag(SEEN_CTHUN) ?? false;
-				//Log.Debug($"Opponent C'Thun Seen: {seenCThun}");
 				return cthun != null;
 			}
 		}

--- a/Hearthstone Deck Tracker/Utility/WotogCounterHelper.cs
+++ b/Hearthstone Deck Tracker/Utility/WotogCounterHelper.cs
@@ -5,6 +5,7 @@ using Hearthstone_Deck_Tracker.Hearthstone.Entities;
 using System;
 using static HearthDb.Enums.GameTag;
 using System.Collections.Generic;
+using Hearthstone_Deck_Tracker.Utility.Logging;
 
 namespace Hearthstone_Deck_Tracker.Utility
 {
@@ -19,8 +20,35 @@ namespace Hearthstone_Deck_Tracker.Utility
 		public static Entity OpponentCthunProxy => Core.Game.Opponent.PlayerEntities.FirstOrDefault(x => x.CardId == CardIds.NonCollectible.Neutral.Cthun);
 		public static Entity PlayerPogoHopper => Core.Game.Player.RevealedEntities.FirstOrDefault(x => x.CardId == CardIds.Collectible.Rogue.PogoHopper && x.Info.OriginalZone != null);
 		public static Entity OpponentPogoHopper => Core.Game.Opponent.RevealedEntities.FirstOrDefault(x => x.CardId == CardIds.Collectible.Rogue.PogoHopper && x.Info.OriginalZone != null);
-		public static bool PlayerSeenCthun => Core.Game.PlayerEntity?.HasTag(SEEN_CTHUN) ?? false;
-		public static bool OpponentSeenCthun => Core.Game.OpponentEntity?.HasTag(SEEN_CTHUN) ?? false;
+
+		public static bool PlayerSeenCthun
+		{
+			get
+			{
+				var cthun = PlayerCthun;
+				//Log.Debug($"Player C'Thun {cthun?.Attack}/{cthun?.Health}");
+				//Log.Debug($"Player C'Thun Proxy {PlayerCthunProxy?.Attack}/{PlayerCthunProxy?.Health}");
+				//var player = Core.Game.PlayerEntity;
+				//var seenCThun = player?.HasTag(SEEN_CTHUN) ?? false;
+				//Log.Debug($"Player C'Thun Seen: {seenCThun}");
+				return cthun != null;
+			}
+		}
+
+		public static bool OpponentSeenCthun
+		{
+			get
+			{
+				var cthun = OpponentCthun;
+				//Log.Debug($"Opponent C'Thun {cthun?.Attack}/{cthun?.Health}");
+				//Log.Debug($"Opponent C'Thun Proxy {OpponentCthunProxy?.Attack}/{OpponentCthunProxy?.Health}");
+				//var player = Core.Game.OpponentEntity;
+				//var seenCThun = player?.HasTag(SEEN_CTHUN) ?? false;
+				//Log.Debug($"Opponent C'Thun Seen: {seenCThun}");
+				return cthun != null;
+			}
+		}
+
 		public static bool? CthunInDeck => DeckContains(CardIds.Collectible.Neutral.CthunOG);
 		public static bool? YoggInDeck => DeckContains(CardIds.Collectible.Neutral.YoggSaronHopesEnd);
 		public static bool? ArcaneGiantInDeck => DeckContains(CardIds.Collectible.Neutral.ArcaneGiant);

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.Update.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.Update.cs
@@ -223,9 +223,9 @@ namespace Hearthstone_Deck_Tracker.Windows
 			var showPlayerAbyssalCurseCounter = WotogCounterHelper.ShowPlayerAbyssalCurseCounter;
 			if(showPlayerCthunCounter)
 			{
-				var proxy = WotogCounterHelper.PlayerCthunProxy;
-				WotogIconsPlayer.Attack = (proxy?.Attack ?? 6).ToString();
-				WotogIconsPlayer.Health = (proxy?.Health ?? 6).ToString();
+				var player = Core.Game.PlayerEntity;
+				WotogIconsPlayer.Attack = (player?.HasTag(CTHUN_ATTACK_BUFF) ?? false ? player.GetTag(CTHUN_ATTACK_BUFF) + 6 : 6).ToString();
+				WotogIconsPlayer.Health = (player?.HasTag(CTHUN_HEALTH_BUFF) ?? false ? player.GetTag(CTHUN_HEALTH_BUFF) + 6 : 6).ToString();
 			}
 			if(showPlayerSpellsCounter)
 				WotogIconsPlayer.Spells = _game.Player.SpellsPlayedCount.ToString();
@@ -255,9 +255,9 @@ namespace Hearthstone_Deck_Tracker.Windows
 			var showOpponentAbyssalCurseCounter = WotogCounterHelper.ShowOpponentAbyssalCurseCounter;
 			if(showOpponentCthunCounter)
 			{
-				var proxy = WotogCounterHelper.OpponentCthunProxy;
-				WotogIconsOpponent.Attack = (proxy?.Attack ?? 6).ToString();
-				WotogIconsOpponent.Health = (proxy?.Health ?? 6).ToString();
+				var player = Core.Game.OpponentEntity;
+				WotogIconsOpponent.Attack = (player?.HasTag(CTHUN_ATTACK_BUFF) ?? false ? player.GetTag(CTHUN_ATTACK_BUFF) + 6 : 6).ToString();
+				WotogIconsOpponent.Health = (player?.HasTag(CTHUN_HEALTH_BUFF) ?? false ? player.GetTag(CTHUN_HEALTH_BUFF) + 6 : 6).ToString();
 			}
 			if(showOpponentSpellsCounter)
 				WotogIconsOpponent.Spells = _game.Opponent.SpellsPlayedCount.ToString();


### PR DESCRIPTION
The way C'Thun is dealt with in-game appears to have changed with the Caverns of Time Twist.

**Issues**
- Player entities never have their SEEN_CTHUN tag set
- C'Thun player/opponent proxies are no longer populated
- PlayerCthun and OpponentCthun entities are populated on the first play of a C'Thun subsidiary card but their attack/health values seem to lag actual values

**Changes**
- Hearthstone Deck Tracker/Utility/WotogCounterHelper.cs
  - Use PlayerCthun/OpponentCthun existence to determine PlayerSeenCthun/OpponentSeenCthun values
- Hearthstone Deck Tracker/Windows/OverlayWindow.Update.cs
  - Get Attack from CTHUN_ATTACK_BUFF player tag value
  - Get Health from CTHUN_HEALTH_BUFF player tag value

Fixes #4490 

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
