### PR TITLE
fix: bobs buddy showing on hero picking

### DIFF
--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.MouseOverDetection.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.MouseOverDetection.cs
@@ -421,10 +421,12 @@ namespace Hearthstone_Deck_Tracker.Windows
 		private async void ShowBobsBuddyPanelDelayed()
 		{
 			await Task.Delay(300);
-			if(!_mouseIsOverLeaderboardIcon)
+			if(!_mouseIsOverLeaderboardIcon &&
+				_game.IsBattlegroundsMatch &&
+				_game.GetTurnNumber() != 0 &&
+				!_game.IsInMenu)
 			{
-				if(_game.IsBattlegroundsMatch && !_game.IsInMenu && _game.GetTurnNumber() != 0)
-					ShowBobsBuddyPanel();
+				ShowBobsBuddyPanel();
 			}
 		}
 

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.MouseOverDetection.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.MouseOverDetection.cs
@@ -423,7 +423,7 @@ namespace Hearthstone_Deck_Tracker.Windows
 			await Task.Delay(300);
 			if(!_mouseIsOverLeaderboardIcon)
 			{
-				if(_game.IsBattlegroundsMatch && !_game.IsInMenu)
+				if(_game.IsBattlegroundsMatch && !_game.IsInMenu && _game.GetTurnNumber() != 0)
 					ShowBobsBuddyPanel();
 			}
 		}


### PR DESCRIPTION
Bos buddy was wrongly being displayed on hero picking after the first match. Checking the turn number ensures we only show Bobs Bubby after the first turn

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [ ] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
