### PR TITLE
fix: always show Tavern Tier 7 setting disabled when Tier7 disabled

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayBattlegrounds.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayBattlegrounds.xaml
@@ -28,7 +28,7 @@
                   Unchecked="CheckboxShowBattlegroundsTiers_Unchecked" Margin="10,5,0,0" />
         <CheckBox x:Name="CheckboxAlwaysShowBattlegroundsTavernTier7" Content="{lex:Loc Options_Overlay_Battlegrounds_CheckBox_AlwaysShowTavernTier7}"
                   HorizontalAlignment="Left" VerticalAlignment="Top"
-                  IsEnabled="{Binding IsChecked, ElementName=CheckboxEnableTier7}"
+                  IsEnabled="{Binding IsChecked, ElementName=CheckboxShowBattlegroundsTiers}"
                   Checked="CheckboxAlwaysShowBattlegroundsTavernTier7_Checked" Unchecked="CheckboxAlwaysShowBattlegroundsTavernTier7_Unchecked"
                   Margin="30,5,0,0" />
         <CheckBox x:Name="CheckboxShowBattlegroundsTurnCounter" Content="{lex:Loc Options_Overlay_General_CheckBox_BattlegroundsTurnCounter}"


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [X] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
