### PR TITLE
Fix InvalidOperationException on empty array

### DIFF
--- a/Hearthstone Deck Tracker/Hearthstone/RelatedCardsSystem/Cards/Priest/ScaleReplica.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/RelatedCardsSystem/Cards/Priest/ScaleReplica.cs
@@ -11,6 +11,10 @@ public class ScaleReplica : ICardWithHighlight
 	public HighlightColor ShouldHighlight(Card card, IEnumerable<Card> deck)
 	{
 		var dragons = deck.Where(c => c.IsDragon()).ToArray();
+		if (dragons.Length == 0) 
+		{
+			return HighlightColor.None;
+		}
 		var lowestCost = dragons.Min(c => c.Cost);
 		var highestCost = dragons.Max(c => c.Cost);
 		return HighlightColorHelper.GetHighlightColor(


### PR DESCRIPTION
<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [X] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

Fix an InvalidOperationException on `dragons.Min` when the current deck contains no dragons.

NB: The CLA signing info in the contributing file seems outdated.