### PR TITLE
feat: add retry functionality for comp stats errors

### DIFF
--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSession.xaml
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSession.xaml
@@ -200,7 +200,7 @@
                                             HorizontalAlignment="Center"
                                             Margin="4 0 4 8"
                                         />
-                                        <Button Content="Retry" Command="{Binding RetryCompStatsCommand}" Width="64" HorizontalAlignment="Center" />
+                                        <Button Content="Retry" Command="{Binding RetryCompStatsCommand}" Width="64" HorizontalAlignment="Center" Style="{StaticResource Tier7ButtonStyle}" Cursor="Hand" />
                                         <TextBlock Text="{Binding CompStatsDebugInfo}" Visibility="{Binding CompStatsDebugVisibility, FallbackValue=Collapsed}" Foreground="#FFFFFF" Opacity=".6" FontSize="10" TextWrapping="Wrap" Margin="6,6,6,0" />
                                     </StackPanel>
                                 </Grid>

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSession.xaml
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSession.xaml
@@ -190,17 +190,19 @@
                                         Visibility="{Binding CompStatsWaitingMsgVisibility, FallbackValue=Collapsed}"
                                         Margin="0 26 0 26"
                                     />
-                                    <TextBlock
-                                        Text="{lex:Loc Battlegrounds_Session_CompStats_ErrorMessage}"
-                                        Foreground="#FFFFFF"
-                                        Opacity=".5"
-                                        TextWrapping="WrapWithOverflow"
-                                        TextAlignment="Center"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        Visibility="{Binding CompStatsErrorVisibility, FallbackValue=Collapsed}"
-                                        Margin="0 26 0 26"
-                                    />
+                                    <StackPanel Orientation="Vertical" Visibility="{Binding CompStatsErrorVisibility, FallbackValue=Collapsed}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 16 0 16">
+                                        <TextBlock
+                                            Text="{lex:Loc Battlegrounds_Session_CompStats_ErrorMessage}"
+                                            Foreground="#FFFFFF"
+                                            Opacity=".5"
+                                            TextWrapping="WrapWithOverflow"
+                                            TextAlignment="Center"
+                                            HorizontalAlignment="Center"
+                                            Margin="4 0 4 8"
+                                        />
+                                        <Button Content="Retry" Command="{Binding RetryCompStatsCommand}" Width="64" HorizontalAlignment="Center" />
+                                        <TextBlock Text="{Binding CompStatsDebugInfo}" Visibility="{Binding CompStatsDebugVisibility, FallbackValue=Collapsed}" Foreground="#FFFFFF" Opacity=".6" FontSize="10" TextWrapping="Wrap" Margin="6,6,6,0" />
+                                    </StackPanel>
                                 </Grid>
                             </StackPanel>
                         </StackPanel>

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSession.xaml
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSession.xaml
@@ -201,7 +201,42 @@
                                             HorizontalAlignment="Center"
                                             Margin="4 0 4 8"
                                         />
-                                        <Button Content="Retry" Command="{Binding RetryCompStatsCommand}" Width="64" HorizontalAlignment="Center" Style="{StaticResource Tier7ButtonStyle}" Cursor="Hand" />
+                                        <battlegrounds:OverlayButton
+                                            HorizontalAlignment="Center"
+                                            Command="{Binding RetryCompStatsCommand}"
+                                            Cursor="Hand"
+                                            Padding="16,10"
+                                            MinWidth="120"
+                                            CornerRadius="4"
+                                        >
+                                            <battlegrounds:OverlayButton.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Background" Value="#F1C040" />
+                                                    <Style.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="Background" Value="#FFD966" />
+                                                        </Trigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </battlegrounds:OverlayButton.Style>
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                <TextBlock
+                                                    Text="⟳"
+                                                    Foreground="#26200F"
+                                                    FontWeight="Bold"
+                                                    FontSize="14"
+                                                    Margin="0,0,6,0"
+                                                    VerticalAlignment="Center"
+                                                />
+                                                <TextBlock
+                                                    Text="{lex:Loc Battlegrounds_CompGuides_Error_Retry}"
+                                                    Foreground="#26200F"
+                                                    FontWeight="Bold"
+                                                    FontSize="13"
+                                                    VerticalAlignment="Center"
+                                                />
+                                            </StackPanel>
+                                        </battlegrounds:OverlayButton>
                                         <TextBlock Text="{Binding CompStatsDebugInfo}" Visibility="{Binding CompStatsDebugVisibility, FallbackValue=Collapsed}" Foreground="#FFFFFF" Opacity=".6" FontSize="10" TextWrapping="Wrap" Margin="6,6,6,0" />
                                     </StackPanel>
                                 </Grid>

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSession.xaml
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSession.xaml
@@ -191,17 +191,19 @@
                                         Visibility="{Binding CompStatsWaitingMsgVisibility, FallbackValue=Collapsed}"
                                         Margin="0 26 0 26"
                                     />
-                                    <TextBlock
-                                        Text="{lex:Loc Battlegrounds_Session_CompStats_ErrorMessage}"
-                                        Foreground="#FFFFFF"
-                                        Opacity=".5"
-                                        TextWrapping="WrapWithOverflow"
-                                        TextAlignment="Center"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        Visibility="{Binding CompStatsErrorVisibility, FallbackValue=Collapsed}"
-                                        Margin="0 26 0 26"
-                                    />
+                                    <StackPanel Orientation="Vertical" Visibility="{Binding CompStatsErrorVisibility, FallbackValue=Collapsed}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0 16 0 16">
+                                        <TextBlock
+                                            Text="{lex:Loc Battlegrounds_Session_CompStats_ErrorMessage}"
+                                            Foreground="#FFFFFF"
+                                            Opacity=".5"
+                                            TextWrapping="WrapWithOverflow"
+                                            TextAlignment="Center"
+                                            HorizontalAlignment="Center"
+                                            Margin="4 0 4 8"
+                                        />
+                                        <Button Content="Retry" Command="{Binding RetryCompStatsCommand}" Width="64" HorizontalAlignment="Center" Style="{StaticResource Tier7ButtonStyle}" Cursor="Hand" />
+                                        <TextBlock Text="{Binding CompStatsDebugInfo}" Visibility="{Binding CompStatsDebugVisibility, FallbackValue=Collapsed}" Foreground="#FFFFFF" Opacity=".6" FontSize="10" TextWrapping="Wrap" Margin="6,6,6,0" />
+                                    </StackPanel>
                                 </Grid>
                             </StackPanel>
                         </StackPanel>

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionViewModel.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionViewModel.xaml.cs
@@ -311,18 +311,28 @@ public class BattlegroundsSessionViewModel : ViewModel
 		catch(Exception e)
 		{
 			HandleCompStatsError(e);
+			return;
 		}
 
 		if(battlegroundsCompStats is BattlegroundsCompStats compStats)
 		{
 			var firstPlaceComps = compStats.Data?.FirstPlaceCompsLobbyRaces;
-			if(firstPlaceComps != null)
+			if(firstPlaceComps != null && firstPlaceComps.Count > 0)
 			{
+				Log.Info($"[Tier7CompStats] Success: received {firstPlaceComps.Count} compositions");
 				SetBattlegroundsCompositionStatsViewModel(
 					firstPlaceComps
 				);
 				ShowCompositionStats();
 			}
+			else
+			{
+				Log.Warn($"[Tier7CompStats] API returned null or empty compositions. compStats.Data={compStats.Data}, firstPlaceComps.Count={firstPlaceComps?.Count ?? 0}");
+			}
+		}
+		else
+		{
+			Log.Warn($"[Tier7CompStats] Received null from API");
 		}
 	}
 

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionViewModel.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionViewModel.xaml.cs
@@ -20,16 +20,23 @@ using Hearthstone_Deck_Tracker.Utility.Extensions;
 using Hearthstone_Deck_Tracker.Utility.Logging;
 using Hearthstone_Deck_Tracker.Utility.MVVM;
 using Hearthstone_Deck_Tracker.Utility.RemoteData;
+using Hearthstone_Deck_Tracker.Commands;
 using HSReplay.Requests;
 using HSReplay.Responses;
 using Newtonsoft.Json;
 using static Hearthstone_Deck_Tracker.Utility.Battlegrounds.BattlegroundsLastGames;
+using System.Windows.Input;
 
 namespace Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds.Session;
 
 public class BattlegroundsSessionViewModel : ViewModel
 {
 	private readonly BattlegroundsDb _db = BattlegroundsDbSingleton.Instance;
+
+	public BattlegroundsSessionViewModel()
+	{
+		RetryCompStatsCommand = new Command(async () => await RetryCompStats());
+	}
 
 	public ObservableCollection<Race> AvailableMinionTypes { get; } = new();
 	public ObservableCollection<Race> BannedMinionTypes { get; } = new();
@@ -49,6 +56,8 @@ public class BattlegroundsSessionViewModel : ViewModel
 	}
 
 	private readonly SemaphoreSlim _updateCompStatsSemaphore = new SemaphoreSlim(1, 1);
+
+	public ICommand RetryCompStatsCommand { get; }
 
 
 	public async void Update()
@@ -187,6 +196,20 @@ public class BattlegroundsSessionViewModel : ViewModel
 
 	    var availableRaces = BattlegroundsUtils.GetAvailableRaces();
 
+	    // Retry logic: game state may not be ready immediately
+	    if(availableRaces == null)
+	    {
+		    Log.Info("[Tier7CompStats] Available races not ready, retrying after delay...");
+		    await Task.Delay(2000);
+		    availableRaces = BattlegroundsUtils.GetAvailableRaces();
+		    
+		    if(availableRaces == null)
+		    {
+			    await Task.Delay(3000);
+			    availableRaces = BattlegroundsUtils.GetAvailableRaces();
+		    }
+	    }
+
 	    if(availableRaces == null)
 		    throw new CompositionStatsException("Unable to get available races");
 
@@ -315,6 +338,7 @@ public class BattlegroundsSessionViewModel : ViewModel
 	private void HandleCompStatsError(Exception error)
 	{
 		Influx.OnGetBattlegroundsCompositionStatsError(error.GetType().Name, error.Message);
+		Log.Error($"[Tier7CompStats] error: {error.GetType().Name} - {error.Message}; debug={CompStatsDebugInfo ?? "<none>"}");
 
 		var beforeHeroPicked = (Core.Game.GameEntity?.GetTag(GameTag.STEP) ?? 0) <= (int)Step.BEGIN_MULLIGAN;
 		if(!beforeHeroPicked)
@@ -330,6 +354,23 @@ public class BattlegroundsSessionViewModel : ViewModel
 		CompStatsErrorVisibility = Visibility.Visible;
 		CompStatsBodyVisibility = Visibility.Hidden;
 		CompStatsWaitingMsgVisibility = Visibility.Hidden;
+	}
+
+	private async Task RetryCompStats()
+	{
+		CompStatsErrorVisibility = Visibility.Hidden;
+		CompStatsBodyVisibility = Visibility.Hidden;
+		CompStatsWaitingMsgVisibility = Visibility.Visible;
+
+		try
+		{
+			await _updateCompStatsSemaphore.WaitAsync();
+			await TrySetCompStats();
+		}
+		finally
+		{
+			_updateCompStatsSemaphore.Release();
+		}
 	}
 
 	private async Task<GameItem?> UpdateLatestGames()
@@ -528,6 +569,20 @@ public class BattlegroundsSessionViewModel : ViewModel
 			OnPropertyChanged();
 		}
 	}
+
+	private string? _compStatsDebugInfo;
+	public string? CompStatsDebugInfo
+	{
+		get => _compStatsDebugInfo;
+		set
+		{
+			_compStatsDebugInfo = value;
+			OnPropertyChanged();
+			OnPropertyChanged(nameof(CompStatsDebugVisibility));
+		}
+	}
+
+	public Visibility CompStatsDebugVisibility => string.IsNullOrWhiteSpace(_compStatsDebugInfo) ? Visibility.Collapsed : Visibility.Visible;
 
 	private Visibility _compStatsWaitingMsgVisibility;
 	public Visibility CompStatsWaitingMsgVisibility

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionViewModel.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionViewModel.xaml.cs
@@ -20,16 +20,23 @@ using Hearthstone_Deck_Tracker.Utility.Extensions;
 using Hearthstone_Deck_Tracker.Utility.Logging;
 using Hearthstone_Deck_Tracker.Utility.MVVM;
 using Hearthstone_Deck_Tracker.Utility.RemoteData;
+using Hearthstone_Deck_Tracker.Commands;
 using HSReplay.Requests;
 using HSReplay.Responses;
 using Newtonsoft.Json;
 using static Hearthstone_Deck_Tracker.Utility.Battlegrounds.BattlegroundsLastGames;
+using System.Windows.Input;
 
 namespace Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds.Session;
 
 public class BattlegroundsSessionViewModel : ViewModel
 {
 	private readonly BattlegroundsDb _db = BattlegroundsDbSingleton.Instance;
+
+	public BattlegroundsSessionViewModel()
+	{
+		RetryCompStatsCommand = new Command(async () => await RetryCompStats());
+	}
 
 	public ObservableCollection<Race> AvailableMinionTypes { get; } = new();
 	public ObservableCollection<Race> BannedMinionTypes { get; } = new();
@@ -57,6 +64,8 @@ public class BattlegroundsSessionViewModel : ViewModel
 	}
 
 	private readonly SemaphoreSlim _updateCompStatsSemaphore = new SemaphoreSlim(1, 1);
+
+	public ICommand RetryCompStatsCommand { get; }
 
 
 	public async void Update()
@@ -199,6 +208,20 @@ public class BattlegroundsSessionViewModel : ViewModel
 
 	    var availableRaces = BattlegroundsUtils.GetAvailableRaces();
 
+	    // Retry logic: game state may not be ready immediately
+	    if(availableRaces == null)
+	    {
+		    Log.Info("[Tier7CompStats] Available races not ready, retrying after delay...");
+		    await Task.Delay(2000);
+		    availableRaces = BattlegroundsUtils.GetAvailableRaces();
+		    
+		    if(availableRaces == null)
+		    {
+			    await Task.Delay(3000);
+			    availableRaces = BattlegroundsUtils.GetAvailableRaces();
+		    }
+	    }
+
 	    if(availableRaces == null)
 		    throw new CompositionStatsException("Unable to get available races");
 
@@ -300,18 +323,28 @@ public class BattlegroundsSessionViewModel : ViewModel
 		catch(Exception e)
 		{
 			HandleCompStatsError(e);
+			return;
 		}
 
 		if(battlegroundsCompStats is BattlegroundsCompStats compStats)
 		{
 			var firstPlaceComps = compStats.Data?.FirstPlaceCompsLobbyRaces;
-			if(firstPlaceComps != null)
+			if(firstPlaceComps != null && firstPlaceComps.Count > 0)
 			{
+				Log.Info($"[Tier7CompStats] Success: received {firstPlaceComps.Count} compositions");
 				SetBattlegroundsCompositionStatsViewModel(
 					firstPlaceComps
 				);
 				ShowCompositionStats();
 			}
+			else
+			{
+				Log.Warn($"[Tier7CompStats] API returned null or empty compositions. compStats.Data={compStats.Data}, firstPlaceComps.Count={firstPlaceComps?.Count ?? 0}");
+			}
+		}
+		else
+		{
+			Log.Warn($"[Tier7CompStats] Received null from API");
 		}
 	}
 
@@ -327,6 +360,7 @@ public class BattlegroundsSessionViewModel : ViewModel
 	private void HandleCompStatsError(Exception error)
 	{
 		Influx.OnGetBattlegroundsCompositionStatsError(error.GetType().Name, error.Message);
+		Log.Error($"[Tier7CompStats] error: {error.GetType().Name} - {error.Message}; debug={CompStatsDebugInfo ?? "<none>"}");
 
 		var beforeHeroPicked = (Core.Game.GameEntity?.GetTag(GameTag.STEP) ?? 0) <= (int)Step.BEGIN_MULLIGAN;
 		if(!beforeHeroPicked)
@@ -342,6 +376,23 @@ public class BattlegroundsSessionViewModel : ViewModel
 		CompStatsErrorVisibility = Visibility.Visible;
 		CompStatsBodyVisibility = Visibility.Hidden;
 		CompStatsWaitingMsgVisibility = Visibility.Hidden;
+	}
+
+	private async Task RetryCompStats()
+	{
+		CompStatsErrorVisibility = Visibility.Hidden;
+		CompStatsBodyVisibility = Visibility.Hidden;
+		CompStatsWaitingMsgVisibility = Visibility.Visible;
+
+		try
+		{
+			await _updateCompStatsSemaphore.WaitAsync();
+			await TrySetCompStats();
+		}
+		finally
+		{
+			_updateCompStatsSemaphore.Release();
+		}
 	}
 
 	private async Task<GameItem?> UpdateLatestGames()
@@ -536,6 +587,20 @@ public class BattlegroundsSessionViewModel : ViewModel
 			OnPropertyChanged();
 		}
 	}
+
+	private string? _compStatsDebugInfo;
+	public string? CompStatsDebugInfo
+	{
+		get => _compStatsDebugInfo;
+		set
+		{
+			_compStatsDebugInfo = value;
+			OnPropertyChanged();
+			OnPropertyChanged(nameof(CompStatsDebugVisibility));
+		}
+	}
+
+	public Visibility CompStatsDebugVisibility => string.IsNullOrWhiteSpace(_compStatsDebugInfo) ? Visibility.Collapsed : Visibility.Visible;
 
 	private Visibility _compStatsWaitingMsgVisibility;
 	public Visibility CompStatsWaitingMsgVisibility


### PR DESCRIPTION
- Implemented a retry mechanism for composition stats retrieval in case of errors.
- Added a "Retry" button in the UI to allow users to manually retry fetching stats.
- Enhanced error logging for better debugging of composition stats issues.

fixes issue #4685

<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [X] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

NOTE: I haven't signed the CLA yet -- the Dev Discord link in the contributing file has an invalid invite :shrug:

I'll drop an email.