### PR TITLE
Fix counter decrement logic in DeathwingDiscount

### DIFF
--- a/Hearthstone Deck Tracker/Hearthstone/CounterSystem/Counters/DeathwingDiscount.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/CounterSystem/Counters/DeathwingDiscount.cs
@@ -54,7 +54,7 @@ public class DeathwingDiscount : NumericCounter
 
 		if(controller == Game.Player.Id && IsPlayerCounter || controller == Game.Opponent.Id && !IsPlayerCounter)
 		{
-			Counter = -value;
+			Counter -= value;
 		}
 	}
 }


### PR DESCRIPTION
Fix it so multiple Deathwing discounts (from playing multiple copies of Ultraxion) stack correctly. 

<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [ ] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->

(This is a one-character functional correction and likely contains no copyrightable authorship.)