### PR TITLE
Fix log watcher after active log truncation

### DIFF
--- a/HDTTests/Utility/LogFileWatcherTest.cs
+++ b/HDTTests/Utility/LogFileWatcherTest.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using HearthWatcher.LogReader;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HDTTests.Utility
+{
+	[TestClass]
+	public class LogFileWatcherTest
+	{
+		[TestMethod]
+		public async Task TruncatedLog_ContinuesReadingFromBeginning()
+		{
+			var directory = Path.Combine(Path.GetTempPath(), "hdt-log-watcher-" + Guid.NewGuid());
+			Directory.CreateDirectory(directory);
+			var filePath = Path.Combine(directory, "Power.log");
+			File.WriteAllText(filePath, string.Empty);
+			var watcher = new LogFileWatcher(new LogWatcherInfo { Name = "Power" });
+
+			try
+			{
+				watcher.Start(DateTime.MinValue, directory);
+				File.WriteAllText(filePath, "D 00:00:00.000 first entry\r\n");
+				Assert.IsTrue(await WaitForLine(watcher, "first entry", TimeSpan.FromSeconds(3)));
+
+				File.WriteAllText(filePath, "D 00:00:01.000 second\r\n");
+				Assert.IsTrue(await WaitForLine(watcher, "second", TimeSpan.FromSeconds(3)));
+			}
+			finally
+			{
+				await watcher.Stop();
+				Directory.Delete(directory, true);
+			}
+		}
+
+		private static async Task<bool> WaitForLine(LogFileWatcher watcher, string value, TimeSpan timeout)
+		{
+			var stopwatch = Stopwatch.StartNew();
+			while(stopwatch.Elapsed < timeout)
+			{
+				if(watcher.Collect().Any(x => x.LineContent.Contains(value)))
+					return true;
+				await Task.Delay(50);
+			}
+			return false;
+		}
+	}
+}

--- a/HearthWatcher/LogReader/LogFileWatcher.cs
+++ b/HearthWatcher/LogReader/LogFileWatcher.cs
@@ -204,6 +204,8 @@ namespace HearthWatcher.LogReader
 					try
 					{
 						fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+						if(fs.Length < _offset)
+							_offset = 0;
 						fs.Seek(_offset, SeekOrigin.Begin);
 						if(fs.Length == _offset)
 						{


### PR DESCRIPTION
Fixes #4732.

## Root cause

`LogFileWatcher` preserved its prior byte offset after the active log was truncated or replaced by a shorter file. Subsequent reads sought beyond EOF and ignored new log lines until the file grew past its previous size.

## Fix

Reset the saved offset when the opened file is shorter than that offset, before seeking.

## Validation

- Added `TruncatedLog_ContinuesReadingFromBeginning`.
- The test fails before the fix and passes after it.
- Full `HDTTests` suite: 209 passed, 0 failed.

Target: `master` commit `c6a9963e69934cc3381c80e00351d44ec3034430`.
