### PR TITLE
Fix formatted flavor text with XML special characters

### DIFF
--- a/HDTTests/Utility/AttachedFormattedStringTests.cs
+++ b/HDTTests/Utility/AttachedFormattedStringTests.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using Hearthstone_Deck_Tracker.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HDTTests.Utility
+{
+	[TestClass]
+	public class AttachedFormattedStringTests
+	{
+		[TestMethod]
+		public void FormattedText_PreservesAmpersand()
+		{
+			var textBlock = new TextBlock();
+
+			AttachedFormattedString.SetFormattedText(textBlock, "A & B");
+
+			var text = string.Concat(textBlock.Inlines.OfType<Run>().Select(x => x.Text));
+			Assert.AreEqual("A & B", text);
+		}
+
+		[TestMethod]
+		public void FormattedText_PreservesBoldTag()
+		{
+			var textBlock = new TextBlock();
+
+			AttachedFormattedString.SetFormattedText(textBlock, "A <b>B</b>");
+
+			var runs = textBlock.Inlines.OfType<Run>().ToArray();
+			Assert.AreEqual(2, runs.Length);
+			Assert.AreEqual("A ", runs[0].Text);
+			Assert.AreEqual("B", runs[1].Text);
+			Assert.AreEqual(FontWeights.Bold, runs[1].FontWeight);
+		}
+	}
+}

--- a/Hearthstone Deck Tracker/Utility/AttachedFormattedString.cs
+++ b/Hearthstone Deck Tracker/Utility/AttachedFormattedString.cs
@@ -38,7 +38,7 @@ namespace Hearthstone_Deck_Tracker.Utility
 			try
 			{
 				//<w> is a wrapper so it gets read as an XElement
-				element = XElement.Parse("<w>" + Regex.Replace(value, @"\<(\w+?)\>", x => x.Captures[0].Value.ToLower()) + "</w>");
+				element = XElement.Parse("<w>" + Regex.Replace(value, @"</?(?:b|i)>|[&<>]", EscapeXmlText) + "</w>");
 			}
 			catch(Exception e)
 			{
@@ -66,6 +66,20 @@ namespace Hearthstone_Deck_Tracker.Utility
 						yield return new Run(xText.Value) { FontStyle = FontStyles.Italic };
 				}
 			}
+		}
+
+		private static string EscapeXmlText(Match match)
+		{
+			var value = match.Value;
+			if(value.Length > 1)
+				return value.ToLowerInvariant();
+			if(value == "&")
+				return "&amp;";
+			if(value == "<")
+				return "&lt;";
+			if(value == ">")
+				return "&gt;";
+			return value;
 		}
 
 		public static string GetFormattedText(DependencyObject dependencyObject)


### PR DESCRIPTION
## Summary

Fix formatted flavor text rendering when the text contains XML special characters such as `&`, `<`, or `>`.

The renderer wraps flavor text in a temporary XML element and parses it with `XElement.Parse`. Supported formatting tags like `<b>` and `<i>` should still work, but plain text XML characters need to be escaped first. Without that, a flavor text value like `A & B` fails XML parsing and renders no text.

Fixes #4734.

## User impact

Users can see an empty flavor text tooltip for specific cards/localizations instead of the actual flavor text. This is probably not very common, but it can happen with card text/localization data.

## Changes

- Escape plain text XML characters before parsing formatted flavor text.
- Preserve supported formatting tags: `<b>`, `</b>`, `<i>`, `</i>`.
- Add regression coverage for ampersands and existing bold formatting behavior.

## Validation

Validated against `origin/master` at `9770f02`.

```text
MSBuild.exe .\HDTTests\HDTTests.csproj /p:Configuration=Debug /p:Platform=x86 /m /v:minimal
vstest.console.exe .\HDTTests\bin\x86\Debug\HDTTests.dll /Tests:FormattedText_PreservesAmpersand,FormattedText_PreservesBoldTag /Platform:x86
vstest.console.exe .\HDTTests\bin\x86\Debug\HDTTests.dll /Platform:x86
```

Results:

- Regression test fails before the fix: expected `A & B`, actual empty string.
- Targeted tests after the fix: 2/2 passed.
- Full test suite after the fix: 210/210 passed.
