### PR TITLE
Record Battlegrounds session game before replay upload

### DIFF
--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -1022,6 +1022,10 @@ namespace Hearthstone_Deck_Tracker
 							_game.CurrentGameStats.BattlegroundsDetails.LobbyRawHeroDbfIds.Add(lobbyHero.Card.DbfId);
 						}
 					}
+
+					RecordBattlegroundsGame();
+					Core.Game.BattlegroundsSessionViewModel.OnGameEnd();
+					Core.Windows.BattlegroundsSessionWindow.OnGameEnd();
 				}
 
 				await SaveReplays(_game.CurrentGameStats);
@@ -1046,10 +1050,7 @@ namespace Hearthstone_Deck_Tracker
 						if(!_game.IsBattlegroundsDuosMatch)
 							Sentry.SendQueuedBobsBuddyEventsStateCompleteFalse(_game.CurrentGameStats.HsReplay.UploadId);
 						Sentry.ClearBattlegroundsEvents();
-					RecordBattlegroundsGame();
 					Tier7Trial.Clear();
-					Core.Game.BattlegroundsSessionViewModel.OnGameEnd();
-					Core.Windows.BattlegroundsSessionWindow.OnGameEnd();
 					Core.Overlay.BattlegroundsGuidesTabsViewModel.Reset();
 					Core.Overlay.BattlegroundsMinionPinningViewModel.Reset();
 					Core.Overlay.BattlegroundsHeroGuideListViewModel.Reset();


### PR DESCRIPTION
## Summary

This fixes a Battlegrounds session recap/latest games issue where HDT could record the wrong game if the player starts another Battlegrounds match while replay saving/upload is still pending.

The Battlegrounds latest-game entry was recorded after `await SaveReplays(...)`. If that await takes long enough, `_game` may already have been reset for the next match by the time `RecordBattlegroundsGame()` runs. In that case HDT can save data from the new in-progress match instead of the completed one.

This moves the Battlegrounds latest-game/session-end recording before `SaveReplays(...)`, while the completed match state is still current.

## User-visible impact

This affects the Battlegrounds session recap / latest games overlay.

In the reproduced case, after quickly starting a new Battlegrounds match, HDT saved a latest-game entry for the new in-progress match instead of the game that had just ended. The saved entry had invalid/incomplete data such as:

- `EndTime = 0001-01-01T00:00:00`
- `Rating = 0`
- start time and hero from the next match
- placement/final board data from the wrong game state

## Validation

I reproduced this in-game with real Battlegrounds matches. To make the timing window deterministic, I used a local validation build with `SaveReplays` delayed by 60 seconds.

### Before the fix

1. Started a Battlegrounds match.
2. Conceded/ended the match.
3. While `SaveReplays` was still delayed, immediately started another Battlegrounds match.
4. After replay saving/upload resumed, `BgsLastGames.xml` was updated with the new in-progress match instead of the completed one.

Observed result:

```text
First game start: 12:34:20
First game end:   12:35:28
Next game start:  12:35:37
Upload finished:  12:36:35
```

The saved latest-game entry used the next game's start time and hero, and had:

```text
EndTime: 0001-01-01T00:00:00
Rating: 0
```

### After the fix

Repeated the same in-game flow with the fix applied:

1. Started a Battlegrounds match.
2. Ended the match.
3. Immediately started another Battlegrounds match while `SaveReplays` was still delayed.
4. The completed game was recorded immediately, before replay saving/upload resumed.

Observed result:

```text
Game start: 12:07:56
Game end:   12:08:58
Next game:  12:09:24
Upload:     12:10:03+
```

`BgsLastGames.xml` contained the completed match with the correct start time, end time, hero, rating, and placement.

### Build

- Built `Hearthstone Deck Tracker.csproj` in Debug/x86 successfully.