### PR TITLE
Fix player overlay deck panel visibility toggles

### DIFF
--- a/Hearthstone Deck Tracker/Controls/ElementSorterItem.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/ElementSorterItem.xaml.cs
@@ -70,17 +70,21 @@ namespace Hearthstone_Deck_Tracker
 				return;
 			_setConfigValue(true);
 			Config.Save();
-			Core.Overlay.Update(false);
 			if(_isPlayerList)
 			{
+				Core.Overlay.UpdatePlayerLayout();
 				Core.Windows.PlayerWindow.Update();
 				Core.Windows.PlayerWindow.UpdatePlayerLayout();
+				Core.UpdatePlayerCards(true);
 			}
 			else
 			{
+				Core.Overlay.UpdateOpponentLayout();
 				Core.Windows.OpponentWindow.Update();
 				Core.Windows.OpponentWindow.UpdateOpponentLayout();
+				Core.UpdateOpponentCards(true);
 			}
+			Core.Overlay.Update(false);
 		}
 
 		private void CheckBox_Unchecked(object sender, RoutedEventArgs e)
@@ -89,17 +93,21 @@ namespace Hearthstone_Deck_Tracker
 				return;
 			_setConfigValue(false);
 			Config.Save();
-			Core.Overlay.Update(false);
 			if(_isPlayerList)
 			{
+				Core.Overlay.UpdatePlayerLayout();
 				Core.Windows.PlayerWindow.Update();
 				Core.Windows.PlayerWindow.UpdatePlayerLayout();
+				Core.UpdatePlayerCards(true);
 			}
 			else
 			{
+				Core.Overlay.UpdateOpponentLayout();
 				Core.Windows.OpponentWindow.Update();
 				Core.Windows.OpponentWindow.UpdateOpponentLayout();
+				Core.UpdateOpponentCards(true);
 			}
+			Core.Overlay.Update(false);
 		}
 	}
 }

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.DeckLists.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.DeckLists.cs
@@ -39,13 +39,16 @@ namespace Hearthstone_Deck_Tracker.Windows
 						StackPanelPlayer.Children.Add(ListViewPlayer);
 						break;
 					case DeckPanel.CardsTop:
-						StackPanelPlayer.Children.Add(PlayerTopDeckLens);
+						if(!Config.Instance.HidePlayerCardsTop)
+							StackPanelPlayer.Children.Add(PlayerTopDeckLens);
 						break;
 					case DeckPanel.CardsBottom:
-						StackPanelPlayer.Children.Add(PlayerBottomDeckLens);
+						if(!Config.Instance.HidePlayerCardsBottom)
+							StackPanelPlayer.Children.Add(PlayerBottomDeckLens);
 						break;
 					case DeckPanel.Sideboards:
-						StackPanelPlayer.Children.Add(PlayerSideboards);
+						if(!Config.Instance.HidePlayerSideboards)
+							StackPanelPlayer.Children.Add(PlayerSideboards);
 						break;
 				}
 			}

--- a/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml.cs
@@ -109,13 +109,16 @@ namespace Hearthstone_Deck_Tracker
 						StackPanelMain.Children.Add(ListViewPlayer);
 						break;
 					case DeckPanel.CardsTop:
-						StackPanelMain.Children.Add(PlayerTopDeckLens);
+						if(!Config.Instance.HidePlayerCardsTop)
+							StackPanelMain.Children.Add(PlayerTopDeckLens);
 						break;
 					case DeckPanel.CardsBottom:
-						StackPanelMain.Children.Add(PlayerBottomDeckLens);
+						if(!Config.Instance.HidePlayerCardsBottom)
+							StackPanelMain.Children.Add(PlayerBottomDeckLens);
 						break;
 					case DeckPanel.Sideboards:
-						StackPanelMain.Children.Add(PlayerSideboards);
+						if(!Config.Instance.HidePlayerSideboards)
+							StackPanelMain.Children.Add(PlayerSideboards);
 						break;
 					case DeckPanel.CardCounter:
 						StackPanelMain.Children.Add(CanvasPlayerCount);


### PR DESCRIPTION
﻿## Summary

Fixes #4681.

This updates the player overlay layout handling so the visibility toggles for:

- cards above the deck
- cards below the deck
- E.T.C.'s Band

are respected by both the main in-game overlay and the standalone player window.

The checkbox handlers now also rebuild the main overlay layout and refresh the current card lists after a visibility change. This prevents the E.T.C.'s Band panel from staying visible after being disabled, and prevents it from coming back empty when toggled off and on again.

## Validation

Tested in-game with a constructed deck containing E.T.C., Band Manager and a filled E.T.C. band.

Before the fix:

- the E.T.C.'s Band panel was visible in the player overlay;
- disabling the `E.T.C.'s Band` option did not hide the panel;
- after partial layout refresh changes, toggling it off and on could bring the panel back empty.

After the fix:

- disabling `E.T.C.'s Band` hides the panel immediately;
- enabling it again restores the panel with all three band cards;
- repeated off/on toggles keep working correctly;
- the same layout visibility checks are applied to the standalone player window.

Build validation:

- `Hearthstone Deck Tracker.csproj`
- `Debug`
- `x86`
