### PR TITLE
Fix Abyssal Curse overlay counter updates

### DIFF
--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -2786,8 +2786,17 @@ namespace Hearthstone_Deck_Tracker
 				card.Info.CostReduction += value;
 		}
 
-		void HandlePlayerAbyssalCurse(int value) => _game.Player.UpdateAbyssalCurse(value);
-		void HandleOpponentAbyssalCurse(int value) => _game.Opponent.UpdateAbyssalCurse(value);
+		void HandlePlayerAbyssalCurse(int value)
+		{
+			_game.Player.UpdateAbyssalCurse(value);
+			_game.CounterManager.HandleAbyssalCurse(false, value);
+		}
+
+		void HandleOpponentAbyssalCurse(int value)
+		{
+			_game.Opponent.UpdateAbyssalCurse(value);
+			_game.CounterManager.HandleAbyssalCurse(true, value);
+		}
 
 		#endregion
 

--- a/Hearthstone Deck Tracker/Hearthstone/CounterSystem/CounterManager.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/CounterSystem/CounterManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using HearthDb.Enums;
+using Hearthstone_Deck_Tracker.Hearthstone.CounterSystem.Counters;
 using Hearthstone_Deck_Tracker.LogReader.Interfaces;
 
 namespace Hearthstone_Deck_Tracker.Hearthstone.CounterSystem;
@@ -81,6 +82,13 @@ public class CounterManager
 		{
 			opponentCounter.HandleChoicePicked(choice);
 		}
+	}
+
+	public void HandleAbyssalCurse(bool controlledByPlayer, int value)
+	{
+		var counters = controlledByPlayer ? PlayerCounters : OpponentCounters;
+		foreach(var counter in counters.OfType<AbyssalCurseCounter>())
+			counter.UpdateAbyssalCurse(value);
 	}
 
 	public void Reset()

--- a/Hearthstone Deck Tracker/Hearthstone/CounterSystem/Counters/AbyssalCurseCounter.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/CounterSystem/Counters/AbyssalCurseCounter.cs
@@ -37,6 +37,11 @@ public class AbyssalCurseCounter : NumericCounter
 
 	public override string ValueToShow() => Counter.ToString();
 
+	internal void UpdateAbyssalCurse(int value)
+	{
+		Counter = value > 0 ? value : Counter + 1;
+	}
+
 	public override void HandleTagChange(GameTag tag, IHsGameState gameState, Entity entity, int value, int prevValue)
 	{
 		if(!Game.IsTraditionalHearthstoneMatch)
@@ -50,7 +55,7 @@ public class AbyssalCurseCounter : NumericCounter
 
 		var controller = entity.GetTag(GameTag.CONTROLLER);
 
-		if((controller == Game.Player.Id && IsPlayerCounter) || (controller == Game.Opponent.Id && !IsPlayerCounter))
+		if((controller == Game.Opponent.Id && IsPlayerCounter) || (controller == Game.Player.Id && !IsPlayerCounter))
 			Counter = value;
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the Abyssal Curse overlay counter not updating after Curse-generating Warlock cards are played.

Closes #4730.

## Root cause

The Abyssal Curse counter was only updated from `TAG_SCRIPT_DATA_NUM_1` tag changes on the Curse token entity. In the current game logs, Curse tokens are created and tracked, but the overlay counter does not reliably receive an update through that tag-change path.

HDT already detects Abyssal Curse creation in `PowerHandler` and updates the internal player/opponent Curse count through `HandlePlayerAbyssalCurse` / `HandleOpponentAbyssalCurse`, but that path did not update the overlay counter system.

There was also a side mismatch for the overlay counter: the visible counter represents the player who created the Curse, while the Curse token itself is controlled by the player who received it.

## Fix

- Update the Abyssal Curse overlay counter from the existing Abyssal Curse game event handlers.
- Route the update to the side that created the Curse.
- Keep the existing tag-change path as a fallback, but align it with the same creator-side semantics.

## Validation

Tested against HDT `v1.53.0` / commit `9fa312ba125cefcbb66d6a544613412db6d3713d`.

Before the fix:

- Used the installed HDT `1.53.0.7337`.
- Played a Warlock deck with Abyssal Curse cards.
- After playing a Curse-generating card, the Abyssal Curse overlay counter stayed at `0`.

After the fix:

- Built HDT from `v1.53.0` with this change.
- Launched the fixed debug build.
- Confirmed in the HDT log:
  - `HDT: 1.53.0.0`
  - active deck: `Custom Warlock`
  - Curse token creation: `TSC_955t`
- Confirmed in-game that the Abyssal Curse counter value updates in the overlay after Curse cards are played.
