### PR TITLE
Show Aessina counter for player decks with Malorne the Waywatcher

### DIFF
--- a/HDTTests/Hearthstone/CounterSystem/FriendlyMinionsDiedThisGameCounterTest.cs
+++ b/HDTTests/Hearthstone/CounterSystem/FriendlyMinionsDiedThisGameCounterTest.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using System.Reflection;
+using Hearthstone_Deck_Tracker;
+using Hearthstone_Deck_Tracker.Hearthstone;
+using Hearthstone_Deck_Tracker.Hearthstone.CounterSystem.Counters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HDTTests.Hearthstone.CounterSystem
+{
+	[TestClass]
+	public class FriendlyMinionsDiedThisGameCounterTest
+	{
+		[TestCleanup]
+		public void Cleanup()
+		{
+			SetActiveDeckWithoutEvents(null);
+		}
+
+		[TestMethod]
+		public void ShouldShowForPlayerDeckWithMalorneTheWaywatcher()
+		{
+			SetActiveDeckWithoutEvents(new Deck
+			{
+				Cards =
+				{
+					new Card(HearthDb.CardIds.Collectible.Neutral.MalorneTheWaywatcher)
+				}
+			});
+
+			var counter = new FriendlyMinionsDiedThisGameCounter(true, new GameV2());
+
+			Assert.IsTrue(counter.ShouldShow());
+			CollectionAssert.AreEqual(
+				new[] { HearthDb.CardIds.Collectible.Mage.Aessina },
+				counter.GetCardsToDisplay().ToArray()
+			);
+		}
+
+		private static void SetActiveDeckWithoutEvents(Deck deck)
+		{
+			typeof(DeckList)
+				.GetField("_activeDeck", BindingFlags.Instance | BindingFlags.NonPublic)
+				.SetValue(DeckList.Instance, deck);
+		}
+	}
+}

--- a/Hearthstone Deck Tracker/Hearthstone/CounterSystem/Counters/FriendlyMinionsDiedThisGameCounter.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/CounterSystem/Counters/FriendlyMinionsDiedThisGameCounter.cs
@@ -18,6 +18,11 @@ public class FriendlyMinionsDiedThisGameCounter: NumericCounter
 		HearthDb.CardIds.Collectible.Mage.Starsurge
 	};
 
+	private static readonly string[] PlayerGeneratorCards = new[]
+	{
+		HearthDb.CardIds.Collectible.Neutral.MalorneTheWaywatcher
+	};
+
 	public FriendlyMinionsDiedThisGameCounter(bool controlledByPlayer, GameV2 game) : base(controlledByPlayer, game)
 	{
 	}
@@ -26,7 +31,7 @@ public class FriendlyMinionsDiedThisGameCounter: NumericCounter
 	{
 		if(!Game.IsTraditionalHearthstoneMatch) return false;
 		if(IsPlayerCounter)
-			return InPlayerDeckOrKnown(RelatedCards);
+			return InPlayerDeckOrKnown(RelatedCards) || InPlayerDeckOrKnown(PlayerGeneratorCards);
 
 		var couldBeGenerated = Game.Opponent.PlayerEntities.Any(e =>
 		{
@@ -51,7 +56,15 @@ public class FriendlyMinionsDiedThisGameCounter: NumericCounter
 	public override string[] GetCardsToDisplay()
 	{
 		if(IsPlayerCounter)
-			return GetCardsInDeckOrKnown(RelatedCards).ToArray();
+		{
+			var cardsInDeckOrKnown = GetCardsInDeckOrKnown(RelatedCards).ToArray();
+			if(cardsInDeckOrKnown.Any())
+				return cardsInDeckOrKnown;
+
+			return InPlayerDeckOrKnown(PlayerGeneratorCards)
+				? new[] { HearthDb.CardIds.Collectible.Mage.Aessina }
+				: new string[] {};
+		}
 
 		var cardsFilteredByClassAndFormat = FilterCardsByClassAndFormat(RelatedCards, Game.Opponent.OriginalClass);
 		return cardsFilteredByClassAndFormat.IsEmpty() ? new[] { HearthDb.CardIds.Collectible.Mage.Aessina } : cardsFilteredByClassAndFormat;


### PR DESCRIPTION
Closes #4710

## Summary

Shows the Aessina friendly-minions-died counter for player decks that include Malorne the Waywatcher.

Malorne can Discover Aessina as one of the Legendary Wild Gods, so the friendly minions died count is relevant before Aessina is actually generated. Without this, the counter only becomes visible after Aessina is created, which is too late to help with the Discover decision.

The counter still displays Aessina as the related card. Malorne is only used as a player-side generator that makes the counter relevant.

Also refreshes visible counters when the active deck changes, so the overlay updates after HDT auto-selects or switches the active deck.

## Validation

- Reproduced on HDT 1.53.2.7343 with a Custom Mage deck containing Malorne the Waywatcher and no Aessina/Starsurge: Aessina counter was not visible in-game.
- Tested the fixed x64 Debug build in-game with the same deck: Aessina counter appeared at the start of the match before Aessina was generated.
- Added regression coverage for showing the player Aessina counter when Malorne is in the active deck.
- Ran `HDTTests` build.
- Ran `FriendlyMinionsDiedThisGameCounterTest.ShouldShowForPlayerDeckWithMalorneTheWaywatcher`.