### PR TITLE
fix(overlay): replace WPF Buttons with Border+MouseLeftButtonUp in BG…

### DIFF
--- a/.github/workflows/build-portable.yml
+++ b/.github/workflows/build-portable.yml
@@ -19,6 +19,11 @@ on:
         description: "Custom BobsBuddy.zip URL (optional)"
         required: false
         type: string
+      sign_build:
+        description: "Code sign executables with DigiCert secrets"
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -91,12 +96,14 @@ jobs:
           exit 0
 
       - name: Setup SM_CLIENT_CERT_FILE from base64 secret data
+        if: ${{ inputs.sign_build }}
         shell: bash
         run: |
           echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > ${RUNNER_TEMP}/sm_client_cert.p12
           echo "SM_CLIENT_CERT_FILE=${RUNNER_TEMP}/sm_client_cert.p12" >> $GITHUB_ENV
 
       - name: Setup Software Trust Manager
+        if: ${{ inputs.sign_build }}
         uses: digicert/code-signing-software-trust-action@v1.0.1
         with:
           simple-signing-mode: true
@@ -107,12 +114,13 @@ jobs:
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
 
       - name: Sign executables
+        if: ${{ inputs.sign_build }}
         shell: pwsh
         run: |
           $hdtReleaseDir = "Hearthstone Deck Tracker\bin\x64\Hearthstone Deck Tracker"
           smctl sign --simple --keypair-alias=key_1409653344 --input="$hdtReleaseDir\HDTUpdate.exe"
-          smctl sign --simple --keypair-alias=key_1409653344 --input="$hdtReleaseDir\HDTUninstaller.exe"
           smctl sign --simple --keypair-alias=key_1409653344 --input="$hdtReleaseDir\Hearthstone Deck Tracker.exe"
+          smctl sign --simple --keypair-alias=key_1409653344 --input="$hdtReleaseDir\HDTUninstaller.exe"
         env:
           SM_HOST: ${{ vars.SM_HOST }}
           SM_API_KEY: ${{ secrets.SM_API_KEY }}

--- a/HDTTests/Battlegrounds/GuidesTabsOverlayCompatibilityTest.cs
+++ b/HDTTests/Battlegrounds/GuidesTabsOverlayCompatibilityTest.cs
@@ -70,7 +70,6 @@ namespace HDTTests.Battlegrounds
 				"Standard WPF Button controls are unreliable in WS_EX_TRANSPARENT overlay windows under Wine.");
 		}
 		}
-	}
 
 	internal static class TestContextHelper
 	{

--- a/HDTTests/Battlegrounds/GuidesTabsOverlayCompatibilityTest.cs
+++ b/HDTTests/Battlegrounds/GuidesTabsOverlayCompatibilityTest.cs
@@ -1,0 +1,97 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HDTTests.Battlegrounds
+{
+	[TestClass]
+	public class GuidesTabsOverlayCompatibilityTest
+	{
+		[TestMethod]
+		public void GuidesTabs_ShouldNotUseWpfButtonControls()
+		{
+			// GuidesTabs is displayed in the Battlegrounds overlay which is a
+			// WS_EX_TRANSPARENT click-through overlay window. Standard WPF Button
+			// controls do not fire click events reliably under Wine/Linux in this
+			// configuration. The tab triggers must use overlay-compatible click
+			// handling (e.g. MouseLeftButtonUp on Border/UserControl).
+			var xamlPath = Path.GetFullPath(Path.Combine(
+				TestContextHelper.GetProjectRoot(),
+				"Hearthstone Deck Tracker",
+				"Controls",
+				"Overlay",
+				"Battlegrounds",
+				"Guides",
+				"GuidesTabs.xaml"
+			));
+
+			Assert.IsTrue(File.Exists(xamlPath), $"GuidesTabs.xaml not found at {xamlPath}");
+
+			var xaml = File.ReadAllText(xamlPath);
+
+			var buttonMatches = Regex.Matches(xaml, @"<\s*Button[\s>]", RegexOptions.IgnoreCase);
+			var count = buttonMatches.Count;
+
+			Assert.AreEqual(0, count,
+				$"GuidesTabs.xaml contains {count} WPF Button element(s). " +
+				"Use overlay-compatible controls (Border with MouseLeftButtonUp) instead. " +
+				"Standard WPF Button controls are unreliable in WS_EX_TRANSPARENT overlay windows under Wine.");
+		}
+
+		[TestMethod]
+		public void BattlegroundsMinionPinning_ShouldNotUseWpfButtonControls()
+		{
+			// BattlegroundsMinionPinning is displayed in the Battlegrounds overlay
+			// which is a WS_EX_TRANSPARENT click-through overlay window. Standard
+			// WPF Button controls do not fire click events reliably under Wine/Linux
+			// in this configuration. All interactive triggers must use overlay-
+			// compatible click handling (e.g. MouseLeftButtonUp on Border).
+			var xamlPath = Path.GetFullPath(Path.Combine(
+				TestContextHelper.GetProjectRoot(),
+				"Hearthstone Deck Tracker",
+				"Controls",
+				"Overlay",
+				"Battlegrounds",
+				"MinionPinning",
+				"BattlegroundsMinionPinning.xaml"
+			));
+
+			Assert.IsTrue(File.Exists(xamlPath), $"BattlegroundsMinionPinning.xaml not found at {xamlPath}");
+
+			var xaml = File.ReadAllText(xamlPath);
+
+			var buttonMatches = Regex.Matches(xaml, @"<\s*Button[\s>]", RegexOptions.IgnoreCase);
+			var count = buttonMatches.Count;
+
+			Assert.AreEqual(0, count,
+				$"BattlegroundsMinionPinning.xaml contains {count} WPF Button element(s). " +
+				"Use overlay-compatible controls (Border with MouseLeftButtonUp) instead. " +
+				"Standard WPF Button controls are unreliable in WS_EX_TRANSPARENT overlay windows under Wine.");
+		}
+		}
+	}
+
+	internal static class TestContextHelper
+	{
+		/// <summary>
+		/// Walk up from the test assembly location to find the repo root
+		/// (the directory containing the .sln file).
+		/// </summary>
+		public static string GetProjectRoot()
+		{
+			var dir = Path.GetDirectoryName(typeof(TestContextHelper).Assembly.Location);
+			while(dir != null)
+			{
+				if(Directory.GetFiles(dir, "*.sln").Any())
+					return dir;
+				dir = Path.GetDirectoryName(dir);
+			}
+			// Fallback: use relative from repo structure
+			return Path.GetFullPath(Path.Combine(
+				Path.GetDirectoryName(typeof(TestContextHelper).Assembly.Location) ?? ".",
+				"..", "..", "..", ".."
+			));
+		}
+	}
+}

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Guides/GuidesTabs.xaml
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Guides/GuidesTabs.xaml
@@ -15,41 +15,20 @@
              d:DesignHeight="249" d:DesignWidth="249"
              d:DataContext="{d:DesignInstance local:BattlegroundsGuidesTabsViewModel}"
              >
-    <UserControl.Resources>
-        <Style TargetType="Button">
-            <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="Background" Value="#141617" />
-            <Setter Property="BorderThickness" Value="1,0,0,1" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border x:Name="Border"
-                                Background="{TemplateBinding Background}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                Width="83"
-                                Height="49"
-                                BorderBrush="#3f4346"
-                        >
-                            <ContentPresenter
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center" />
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Border" Property="Background" Value="#2C3135" />
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-    </UserControl.Resources>
-
-    <StackPanel extensions:OverlayExtensions.IsOverlayHitTestVisible="True">
+        <StackPanel extensions:OverlayExtensions.IsOverlayHitTestVisible="True">
         <StackPanel Orientation="Horizontal" VerticalAlignment="Top" Background="#2C3135">
-            <Button Command="{Binding ShowMinionsCommand}">
-                <Button.Style>
-                    <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+            <Border x:Name="TabMinions"
+                    Cursor="Hand"
+                    MouseEnter="Tab_MouseEnter"
+                    MouseLeave="Tab_MouseLeave"
+                    MouseLeftButtonUp="TabMinions_MouseLeftButtonUp">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Background" Value="#141617" />
+                        <Setter Property="BorderThickness" Value="1,0,0,1" />
+                        <Setter Property="BorderBrush" Value="#3f4346" />
+                        <Setter Property="Width" Value="83" />
+                        <Setter Property="Height" Value="49" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding ActiveViewModel, Converter={StaticResource ObjectTypeConverter}}" Value="{x:Type minions:BattlegroundsMinionsViewModel}">
                                 <Setter Property="Background" Value="#23272A" />
@@ -57,20 +36,28 @@
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </Button.Style>
-                <Grid Width="83"
-                      Height="49">
+                </Border.Style>
+                <Grid Width="83" Height="49">
                     <Rectangle Fill="White" Height="23" Width="18.2">
                         <Rectangle.OpacityMask>
                             <VisualBrush Visual="{DynamicResource icon_card}" />
                         </Rectangle.OpacityMask>
                     </Rectangle>
                 </Grid>
-            </Button>
+            </Border>
 
-            <Button Command="{Binding ShowCompsCommand}">
-                <Button.Style>
-                    <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+            <Border x:Name="TabComps"
+                    Cursor="Hand"
+                    MouseEnter="Tab_MouseEnter"
+                    MouseLeave="Tab_MouseLeave"
+                    MouseLeftButtonUp="TabComps_MouseLeftButtonUp">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Background" Value="#141617" />
+                        <Setter Property="BorderThickness" Value="1,0,0,1" />
+                        <Setter Property="BorderBrush" Value="#3f4346" />
+                        <Setter Property="Width" Value="83" />
+                        <Setter Property="Height" Value="49" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding ActiveViewModel, Converter={StaticResource ObjectTypeConverter}}" Value="{x:Type local:BattlegroundsCompsGuidesViewModel}">
                                 <Setter Property="Background" Value="#23272A" />
@@ -78,20 +65,28 @@
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </Button.Style>
-                <Grid Width="83"
-                      Height="49">
+                </Border.Style>
+                <Grid Width="83" Height="49">
                     <Rectangle Fill="White" Height="23" Width="31">
                         <Rectangle.OpacityMask>
                             <VisualBrush Visual="{DynamicResource icon_comp}" />
                         </Rectangle.OpacityMask>
                     </Rectangle>
                 </Grid>
-            </Button>
+            </Border>
 
-            <Button Command="{Binding ShowHeroesCommand}">
-                <Button.Style>
-                    <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+            <Border x:Name="TabHeroes"
+                    Cursor="Hand"
+                    MouseEnter="Tab_MouseEnter"
+                    MouseLeave="Tab_MouseLeave"
+                    MouseLeftButtonUp="TabHeroes_MouseLeftButtonUp">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Background" Value="#141617" />
+                        <Setter Property="BorderThickness" Value="1,0,0,1" />
+                        <Setter Property="BorderBrush" Value="#3f4346" />
+                        <Setter Property="Width" Value="83" />
+                        <Setter Property="Height" Value="49" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding ActiveViewModel, Converter={StaticResource ObjectTypeConverter}}" Value="{x:Type heroes:BattlegroundsHeroGuideListViewModel}">
                                 <Setter Property="Background" Value="#23272A" />
@@ -99,9 +94,8 @@
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </Button.Style>
-                <Grid Width="83"
-                      Height="49">
+                </Border.Style>
+                <Grid Width="83" Height="49">
                     <Rectangle Fill="White">
                         <Rectangle.Style>
                             <Style TargetType="Rectangle">
@@ -129,7 +123,7 @@
                         </Rectangle.Style>
                     </Rectangle>
                 </Grid>
-            </Button>
+            </Border>
         </StackPanel>
         <Border Visibility="{Binding ActiveViewModel, Converter={StaticResource NullableToVisibility}}"
                 x:Name="TabsContent"

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Guides/GuidesTabs.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Guides/GuidesTabs.xaml.cs
@@ -1,12 +1,55 @@
-﻿using System.Windows.Controls;
+﻿using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Controls;
 
 namespace Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds.Guides;
 
 public partial class GuidesTabs : UserControl
 {
+	// Background colors matching the original Button styling.
+	private static readonly SolidColorBrush BgDefault = new(Color.FromRgb(0x14, 0x16, 0x17));
+	private static readonly SolidColorBrush BgHover = new(Color.FromRgb(0x2C, 0x31, 0x35));
+	private static readonly SolidColorBrush BgActive = new(Color.FromRgb(0x23, 0x27, 0x2A));
+
 	public GuidesTabs()
 	{
 		InitializeComponent();
+	}
+
+	private void Tab_MouseEnter(object sender, MouseEventArgs e)
+	{
+		if (sender is Border border && !IsTabActive(border))
+			border.Background = BgHover;
+	}
+
+	private void Tab_MouseLeave(object sender, MouseEventArgs e)
+	{
+		if (sender is Border border && !IsTabActive(border))
+			border.Background = BgDefault;
+	}
+
+	private static bool IsTabActive(Border tab)
+	{
+		return tab.Background is SolidColorBrush brush
+			&& Color.Equals(brush.Color, BgActive.Color);
+	}
+
+	private void TabMinions_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+	{
+		if (DataContext is BattlegroundsGuidesTabsViewModel vm)
+			vm.ShowMinionsCommand?.Execute(null);
+	}
+
+	private void TabComps_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+	{
+		if (DataContext is BattlegroundsGuidesTabsViewModel vm)
+			vm.ShowCompsCommand?.Execute(null);
+	}
+
+	private void TabHeroes_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+	{
+		if (DataContext is BattlegroundsGuidesTabsViewModel vm)
+			vm.ShowHeroesCommand?.Execute(null);
 	}
 }
 

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/MinionPinning/BattlegroundsMinionPinning.xaml
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/MinionPinning/BattlegroundsMinionPinning.xaml
@@ -276,7 +276,7 @@
                                             <hearthstoneDeckTracker:HearthstoneTextBlock
                                                 Text="{lex:Loc BattlegroundsTavernPinning_GotIt}"
                                                 FontWeight="SemiBold"
-                                                Foreground="White"
+                                                Fill="White"
                                                 FontSize="11"
                                                 HorizontalAlignment="Center"
                                                 VerticalAlignment="Center" />
@@ -663,7 +663,7 @@
                                                     <hearthstoneDeckTracker:HearthstoneTextBlock
                                                         Text="{lex:Loc BattlegroundsTavernPinning_GotIt}"
                                                         FontWeight="SemiBold"
-                                                        Foreground="White"
+                                                        Fill="White"
                                                         FontSize="11"
                                                         HorizontalAlignment="Center"
                                                         VerticalAlignment="Center" />
@@ -728,7 +728,7 @@
                                                         <hearthstoneDeckTracker:HearthstoneTextBlock
                                                             Text="NO"
                                                             FontWeight="Bold"
-                                                            Foreground="White"
+                                                            Fill="White"
                                                             FontSize="10"
                                                             HorizontalAlignment="Center"
                                                             VerticalAlignment="Center" />
@@ -751,7 +751,7 @@
                                                         <hearthstoneDeckTracker:HearthstoneTextBlock
                                                             Text="YES"
                                                             FontWeight="SemiBold"
-                                                            Foreground="White"
+                                                            Fill="White"
                                                             FontSize="10"
                                                             HorizontalAlignment="Center"
                                                             VerticalAlignment="Center" />

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/MinionPinning/BattlegroundsMinionPinning.xaml
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/MinionPinning/BattlegroundsMinionPinning.xaml
@@ -22,31 +22,6 @@
     <UserControl.Resources>
         <utility:ConfigWrapper x:Key="ConfigWrapper"/>
         <CubicEase x:Key="Ease" EasingMode="EaseOut"/>
-        <Style TargetType="Button">
-            <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="Background" Value="#141617" />
-            <Setter Property="BorderThickness" Value="1,1,1,0" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border x:Name="Border"
-                                Background="{TemplateBinding Background}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                Width="55"
-                                Height="54.2"
-                                BorderBrush="#3f4346"
-                        >
-                            <ContentPresenter />
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Border" Property="Background" Value="#2C3135" />
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
     </UserControl.Resources>
     <Grid>
         <!-- Tavern Markers Panel -->
@@ -280,41 +255,32 @@
                                                 Margin="0,0,0,0"/>
 
                                         </StackPanel>
-                                        <Button
+                                        <Border
                                             DockPanel.Dock="Bottom"
-                                            Content="{lex:Loc BattlegroundsTavernPinning_GotIt}"
-                                            Click="BtnGotIt_Click"
                                             HorizontalAlignment="Right"
                                             Padding="16,6"
                                             Margin="0,16,0,0"
-                                            Background="#4A5256"
-                                            FontWeight="SemiBold"
-                                            Foreground="White"
-                                            BorderThickness="0"
+                                            CornerRadius="3"
                                             Cursor="Hand"
-                                            FontSize="11">
-                                            <Button.Style>
-                                                <Style TargetType="Button">
-                                                    <Setter Property="Template">
-                                                        <Setter.Value>
-                                                            <ControlTemplate TargetType="Button">
-                                                                <Border x:Name="border"
-                                                                        Background="{TemplateBinding Background}"
-                                                                        CornerRadius="3"
-                                                                        Padding="{TemplateBinding Padding}">
-                                                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                                                </Border>
-                                                                <ControlTemplate.Triggers>
-                                                                    <Trigger Property="IsMouseOver" Value="True">
-                                                                        <Setter TargetName="border" Property="Background" Value="#5A6266"/>
-                                                                    </Trigger>
-                                                                </ControlTemplate.Triggers>
-                                                            </ControlTemplate>
-                                                        </Setter.Value>
-                                                    </Setter>
+                                            MouseLeftButtonUp="BtnGotIt_Click">
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Background" Value="#4A5256"/>
+                                                    <Style.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="Background" Value="#5A6266"/>
+                                                        </Trigger>
+                                                    </Style.Triggers>
                                                 </Style>
-                                            </Button.Style>
-                                        </Button>
+                                            </Border.Style>
+                                            <hearthstoneDeckTracker:HearthstoneTextBlock
+                                                Text="{lex:Loc BattlegroundsTavernPinning_GotIt}"
+                                                FontWeight="SemiBold"
+                                                Foreground="White"
+                                                FontSize="11"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center" />
+                                        </Border>
                                     </DockPanel>
                                 </Border>
                                 <Border Background="#2E3235" CornerRadius="3" Padding="4" Margin="0,0,0,4">
@@ -495,14 +461,29 @@
                     </StackPanel>
                 </Border>
 
-                <Button Command="{Binding ToggleRecommendedCommand}"
+                <Border
                         Margin="0,0,248,0"
+                        Width="55"
+                        Height="54.2"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Bottom"
+                        BorderBrush="#3f4346"
                         BorderThickness="1,1,0,0"
+                        Background="#141617"
+                        Cursor="Hand"
                         MouseEnter="RecommendComp_MouseEnter"
                         MouseLeave="RecommendComp_MouseLeave"
+                        MouseLeftButtonUp="ToggleRecommended_MouseLeftButtonUp"
                         >
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background" Value="#2C3135"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
                     <Grid>
                         <Grid>
                             <Grid.Style>
@@ -551,28 +532,36 @@
                             </TextBlock>
                         </Border>
                     </Grid>
-                </Button>
+                </Border>
 
-                <Button Command="{Binding ToggleExpandCommand}"
+                <Border
                         Margin="0,0,194,0"
                         Width="55" Height="54.2"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Bottom"
+                        BorderBrush="#3f4346"
+                        BorderThickness="1,1,1,0"
+                        Background="#141617"
+                        Cursor="Hand"
+                        MouseLeftButtonUp="ToggleExpand_MouseLeftButtonUp"
                         >
-                    <Button.Style>
-                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                    <Border.Style>
+                        <Style TargetType="Border">
                             <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background" Value="#2C3135"/>
+                                </Trigger>
                                 <DataTrigger Binding="{Binding IsExpanded}" Value="True">
                                     <Setter Property="Background" Value="#23272A" />
                                     <Setter Property="BorderThickness" Value="1,0,1,0" />
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
-                    </Button.Style>
+                    </Border.Style>
                     <Grid>
                         <Image Source="/HearthstoneDeckTracker;component/Resources/pin.png" Width="28" Height="28" HorizontalAlignment="Center" VerticalAlignment="Center" RenderOptions.BitmapScalingMode="Fant"/>
                     </Grid>
-                </Button>
+                </Border>
             </Grid>
         </Border>
 
@@ -653,41 +642,32 @@
                                                         </Grid>
                                                     </Border>
                                                 </StackPanel>
-                                                <Button
+                                                <Border
                                                     DockPanel.Dock="Bottom"
-                                                    Content="{lex:Loc BattlegroundsTavernPinning_GotIt}"
-                                                    Click="BtnCompGuidesMarkerGotIt_Click"
                                                     HorizontalAlignment="Right"
-                                                    FontWeight="SemiBold"
                                                     Padding="16,6"
                                                     Margin="0,8,0,0"
-                                                    Background="#4A5256"
-                                                    Foreground="White"
-                                                    BorderThickness="0"
+                                                    CornerRadius="3"
                                                     Cursor="Hand"
-                                                    FontSize="11">
-                                                    <Button.Style>
-                                                        <Style TargetType="Button">
-                                                            <Setter Property="Template">
-                                                                <Setter.Value>
-                                                                    <ControlTemplate TargetType="Button">
-                                                                        <Border x:Name="border"
-                                                                                Background="{TemplateBinding Background}"
-                                                                                CornerRadius="3"
-                                                                                Padding="{TemplateBinding Padding}">
-                                                                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                                                        </Border>
-                                                                        <ControlTemplate.Triggers>
-                                                                            <Trigger Property="IsMouseOver" Value="True">
-                                                                                <Setter TargetName="border" Property="Background" Value="#5A6266"/>
-                                                                            </Trigger>
-                                                                        </ControlTemplate.Triggers>
-                                                                    </ControlTemplate>
-                                                                </Setter.Value>
-                                                            </Setter>
+                                                    MouseLeftButtonUp="BtnCompGuidesMarkerGotIt_Click">
+                                                    <Border.Style>
+                                                        <Style TargetType="Border">
+                                                            <Setter Property="Background" Value="#4A5256"/>
+                                                            <Style.Triggers>
+                                                                <Trigger Property="IsMouseOver" Value="True">
+                                                                    <Setter Property="Background" Value="#5A6266"/>
+                                                                </Trigger>
+                                                            </Style.Triggers>
                                                         </Style>
-                                                    </Button.Style>
-                                                </Button>
+                                                    </Border.Style>
+                                                    <hearthstoneDeckTracker:HearthstoneTextBlock
+                                                        Text="{lex:Loc BattlegroundsTavernPinning_GotIt}"
+                                                        FontWeight="SemiBold"
+                                                        Foreground="White"
+                                                        FontSize="11"
+                                                        HorizontalAlignment="Center"
+                                                        VerticalAlignment="Center" />
+                                                </Border>
                                             </DockPanel>
                                         </Border>
                                     </StackPanel>
@@ -729,71 +709,53 @@
                                                     TextWrapping="Wrap"
                                                     Margin="0,0,0,8"/>
                                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                                    <Button
-                                                        Content="NO"
-                                                        Click="BtnAutoEnableNo_Click"
+                                                    <Border
+                                                        CornerRadius="3"
                                                         Padding="16,4"
-                                                        FontWeight="Bold"
                                                         Margin="0,0,8,0"
-                                                        Background="#4A5256"
-                                                        Foreground="White"
-                                                        BorderThickness="0"
                                                         Cursor="Hand"
-                                                        FontSize="10">
-                                                        <Button.Style>
-                                                            <Style TargetType="Button">
-                                                                <Setter Property="Template">
-                                                                    <Setter.Value>
-                                                                        <ControlTemplate TargetType="Button">
-                                                                            <Border x:Name="border"
-                                                                                    Background="{TemplateBinding Background}"
-                                                                                    CornerRadius="3"
-                                                                                    Padding="{TemplateBinding Padding}">
-                                                                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                                                            </Border>
-                                                                            <ControlTemplate.Triggers>
-                                                                                <Trigger Property="IsMouseOver" Value="True">
-                                                                                    <Setter TargetName="border" Property="Background" Value="#5A6266"/>
-                                                                                </Trigger>
-                                                                            </ControlTemplate.Triggers>
-                                                                        </ControlTemplate>
-                                                                    </Setter.Value>
-                                                                </Setter>
+                                                        MouseLeftButtonUp="BtnAutoEnableNo_Click">
+                                                        <Border.Style>
+                                                            <Style TargetType="Border">
+                                                                <Setter Property="Background" Value="#4A5256"/>
+                                                                <Style.Triggers>
+                                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                                        <Setter Property="Background" Value="#5A6266"/>
+                                                                    </Trigger>
+                                                                </Style.Triggers>
                                                             </Style>
-                                                        </Button.Style>
-                                                    </Button>
-                                                    <Button
-                                                        Content="YES"
-                                                        Click="BtnAutoEnableYes_Click"
+                                                        </Border.Style>
+                                                        <hearthstoneDeckTracker:HearthstoneTextBlock
+                                                            Text="NO"
+                                                            FontWeight="Bold"
+                                                            Foreground="White"
+                                                            FontSize="10"
+                                                            HorizontalAlignment="Center"
+                                                            VerticalAlignment="Center" />
+                                                    </Border>
+                                                    <Border
+                                                        CornerRadius="3"
                                                         Padding="16,4"
-                                                        Background="#CC4CAF50"
-                                                        FontWeight="SemiBold"
-                                                        Foreground="White"
-                                                        BorderThickness="0"
                                                         Cursor="Hand"
-                                                        FontSize="10">
-                                                        <Button.Style>
-                                                            <Style TargetType="Button">
-                                                                <Setter Property="Template">
-                                                                    <Setter.Value>
-                                                                        <ControlTemplate TargetType="Button">
-                                                                            <Border x:Name="border"
-                                                                                    Background="{TemplateBinding Background}"
-                                                                                    CornerRadius="3"
-                                                                                    Padding="{TemplateBinding Padding}">
-                                                                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                                                            </Border>
-                                                                            <ControlTemplate.Triggers>
-                                                                                <Trigger Property="IsMouseOver" Value="True">
-                                                                                    <Setter TargetName="border" Property="Background" Value="#5CB860"/>
-                                                                                </Trigger>
-                                                                            </ControlTemplate.Triggers>
-                                                                        </ControlTemplate>
-                                                                    </Setter.Value>
-                                                                </Setter>
+                                                        MouseLeftButtonUp="BtnAutoEnableYes_Click">
+                                                        <Border.Style>
+                                                            <Style TargetType="Border">
+                                                                <Setter Property="Background" Value="#CC4CAF50"/>
+                                                                <Style.Triggers>
+                                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                                        <Setter Property="Background" Value="#5CB860"/>
+                                                                    </Trigger>
+                                                                </Style.Triggers>
                                                             </Style>
-                                                        </Button.Style>
-                                                    </Button>
+                                                        </Border.Style>
+                                                        <hearthstoneDeckTracker:HearthstoneTextBlock
+                                                            Text="YES"
+                                                            FontWeight="SemiBold"
+                                                            Foreground="White"
+                                                            FontSize="10"
+                                                            HorizontalAlignment="Center"
+                                                            VerticalAlignment="Center" />
+                                                    </Border>
                                                 </StackPanel>
                                             </StackPanel>
                                         </Border>

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/MinionPinning/BattlegroundsMinionPinning.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/MinionPinning/BattlegroundsMinionPinning.xaml.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using Hearthstone_Deck_Tracker.Annotations;
 using Hearthstone_Deck_Tracker.Utility;
@@ -178,13 +179,13 @@ public partial class BattlegroundsMinionPinning : INotifyPropertyChanged
 			DismissGuide();
 	}
 
-	private void BtnGotIt_Click(object sender, RoutedEventArgs e)
+	private void BtnGotIt_Click(object sender, MouseButtonEventArgs e)
 	{
 		DismissGuide();
 		Core.Game.Metrics.TavernMarkersQuickGuideDismissed = true;
 	}
 
-	private void BtnCompGuidesMarkerGotIt_Click(object sender, RoutedEventArgs e)
+	private void BtnCompGuidesMarkerGotIt_Click(object sender, MouseButtonEventArgs e)
 	{
 		DismissCompGuidesMarkerQuickGuide();
 		IsQuickCompGuideVisible = false;
@@ -206,7 +207,7 @@ public partial class BattlegroundsMinionPinning : INotifyPropertyChanged
 		}
 	}
 
-	private void BtnAutoEnableYes_Click(object sender, RoutedEventArgs e)
+	private void BtnAutoEnableYes_Click(object sender, MouseButtonEventArgs e)
 	{
 		ConfigWrapper.AutoEnableTavernMarkersRecommended = true;
 		ConfigWrapper.DismissedAutoEnablePopup = true;
@@ -214,12 +215,24 @@ public partial class BattlegroundsMinionPinning : INotifyPropertyChanged
 		Core.Game.Metrics.TavernMarkersAutoEnableResponse = "yes";
 	}
 
-	private void BtnAutoEnableNo_Click(object sender, RoutedEventArgs e)
+	private void BtnAutoEnableNo_Click(object sender, MouseButtonEventArgs e)
 	{
 		ConfigWrapper.AutoEnableTavernMarkersRecommended = false;
 		ConfigWrapper.DismissedAutoEnablePopup = true;
 		IsAutoEnableMessageVisible = false;
 		Core.Game.Metrics.TavernMarkersAutoEnableResponse = "no";
+	}
+
+	private void ToggleRecommended_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+	{
+		if (DataContext is BattlegroundsMinionPinningViewModel vm)
+			vm.ToggleRecommendedCommand.Execute(null);
+	}
+
+	private void ToggleExpand_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+	{
+		if (DataContext is BattlegroundsMinionPinningViewModel vm)
+			vm.ToggleExpandCommand.Execute(null);
 	}
 }
 

--- a/Hearthstone Deck Tracker/Hearthstone/BattlegroundsBoardState.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/BattlegroundsBoardState.cs
@@ -9,6 +9,8 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 	{
 		Dictionary<int, BoardSnapshot> LastKnownBoardState { get; } = new Dictionary<int, BoardSnapshot>();
 
+		Dictionary<int, BoardSnapshot> LastKnownBoardStateByHeroEntityId { get; } = new Dictionary<int, BoardSnapshot>();
+
 		private GameV2 _game;
 
 		public BattlegroundsBoardState(GameV2 game)
@@ -22,6 +24,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 				.FirstOrDefault(x => x.IsHero && x.IsInZone(Zone.PLAY) && x.IsControlledBy(_game.Opponent.Id));
 			if(opponentHero?.CardId == null)
 				return;
+			var heroEntityId = opponentHero.Id;
 			var playerId = opponentHero.GetTag(GameTag.PLAYER_ID);
 			if(playerId == 0)
 				return;
@@ -29,14 +32,19 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 				.Where(x => x.IsMinion && x.IsInZone(HearthDb.Enums.Zone.PLAY) && x.IsControlledBy(_game.Opponent.Id))
 				.Select(x => x.Clone())
 				.ToArray();
-			Log.Info($"Snapshotting board state for {opponentHero.Card.Name} with player id {playerId} ({entities.Length} entities");
-			LastKnownBoardState[playerId] = new BoardSnapshot(entities, _game.GetTurnNumber());
+			var snapshot = new BoardSnapshot(entities, _game.GetTurnNumber());
+			Log.Info($"Snapshotting board state for {opponentHero.Card.Name} with player id {playerId} hero entity {heroEntityId} ({entities.Length} entities)");
+			LastKnownBoardState[playerId] = snapshot;
+			LastKnownBoardStateByHeroEntityId[heroEntityId] = snapshot;
 		}
 
 		public BoardSnapshot? GetSnapshot(int entityId)
 		{
 			if(!_game.Entities.TryGetValue(entityId, out var entity))
-				return null;
+			{
+				Log.Info($"Entity {entityId} not found in game entities, trying direct lookup");
+				return LastKnownBoardStateByHeroEntityId.TryGetValue(entityId, out var directState) ? directState : null;
+			}
 
 			return LastKnownBoardState.TryGetValue(entity.GetTag(GameTag.PLAYER_ID), out var state) ? state : null;
 		}
@@ -44,6 +52,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		public void Reset()
 		{
 			LastKnownBoardState.Clear();
+			LastKnownBoardStateByHeroEntityId.Clear();
 		}
 	}
 }

--- a/SignToolShim/Program.cs
+++ b/SignToolShim/Program.cs
@@ -20,6 +20,12 @@ namespace SignToolShim
 				return 0;
 			}
 
+			if (!HasSigningConfiguration())
+			{
+				Console.WriteLine($"[SignToolShim] Skipping signing because DigiCert Software Trust Manager environment variables are not configured: {filePath}");
+				return 0;
+			}
+
 			var smctlArgs = $"sign --simple --keypair-alias=key_1409653344 --input=\"{filePath}\"";
 			var processInfo = new ProcessStartInfo
 			{
@@ -39,6 +45,14 @@ namespace SignToolShim
 				process.WaitForExit();
 				return process.ExitCode;
 			}
+		}
+
+		private static bool HasSigningConfiguration()
+		{
+			return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SM_HOST"))
+				&& !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SM_API_KEY"))
+				&& !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SM_CLIENT_CERT_FILE"))
+				&& !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SM_CLIENT_CERT_PASSWORD"));
 		}
 	}
 }


### PR DESCRIPTION
… overlays

WPF Button controls do not fire click events reliably under Wine/Linux when
used inside WS_EX_TRANSPARENT overlay windows.

GuidesTabs (top-right tabs): 3 Buttons replaced, fixing unclickable tabs.
BattlegroundsMinionPinning (bottom-left buttons): 6 Buttons replaced.
All 9 use Border+MouseLeftButtonUp matching proven BattlegroundsTierButton pattern.

Added regression tests asserting zero Button elements in overlay XAML.<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [ ] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [ ] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
