### PR TITLE
Add collection export to file

### DIFF
--- a/HDTTests/Hearthstone/CollectionTest.cs
+++ b/HDTTests/Hearthstone/CollectionTest.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using HearthMirror.Objects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using HDTCollection = Hearthstone_Deck_Tracker.Hearthstone.Collection;
+
+namespace HDTTests.Hearthstone
+{
+	[TestClass]
+	public class CollectionTest
+	{
+		// Builds a collection with a single card owned in two premium variants
+		// (2 normal + 1 golden) so the premium-count layout can be asserted.
+		private static HDTCollection BuildCollection()
+		{
+			var mirror = new Collection();
+			mirror.Cards.Add(new Card("HDT_TEST_CARD", 2, 0, 0));
+			mirror.Cards.Add(new Card("HDT_TEST_CARD", 1, 1, 0));
+			var battleTag = new BattleTag { Name = "Tester", Number = "1234" };
+			return new HDTCollection(1, 2, battleTag, mirror);
+		}
+
+		[TestMethod]
+		public void Serialize_ProducesHSReplayTopLevelKeys()
+		{
+			var json = JObject.Parse(JsonConvert.SerializeObject(BuildCollection()));
+			CollectionAssert.AreEquivalent(
+				new[] { "collection", "favorite_heroes", "cardbacks", "favorite_cardback", "dust", "player_records" },
+				json.Properties().Select(p => p.Name).ToArray());
+		}
+
+		[TestMethod]
+		public void Serialize_OmitsAccountIdentifiers()
+		{
+			var json = JsonConvert.SerializeObject(BuildCollection());
+			StringAssert.DoesNotMatch(json, new Regex("AccountHi|AccountLo|BattleTag"));
+		}
+
+		[TestMethod]
+		public void Serialize_GroupsCardCountsByPremiumType()
+		{
+			var json = JObject.Parse(JsonConvert.SerializeObject(BuildCollection()));
+			var cards = (JObject)json["collection"];
+			Assert.AreEqual(1, cards.Count);
+			var counts = cards.Properties().First().Value.ToObject<int[]>();
+			// [normal, golden, diamond, signature, trial x4]
+			CollectionAssert.AreEqual(new[] { 2, 1, 0, 0, 0, 0, 0, 0 }, counts);
+		}
+
+		[TestMethod]
+		public void Size_SumsAllCardCounts()
+		{
+			Assert.AreEqual(3, BuildCollection().Size());
+		}
+	}
+}

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/HSReplay/HSReplayCollection.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/HSReplay/HSReplayCollection.xaml
@@ -61,6 +61,13 @@
                 <TextBlock Text="{lex:Loc Banner_CollectionSyncing_Subtitle}" VerticalAlignment="Center" TextWrapping="Wrap"
                            HorizontalAlignment="Center" FontSize="14" Margin="20,4"/>
             </Button>
+            <Button Style="{DynamicResource AccentedSquareButtonStyle}" HorizontalAlignment="Center"
+                    Command="{Binding ExportCollectionCommand}"
+                    BorderThickness="1" BorderBrush="White" Foreground="White" MinWidth="200"
+                    Margin="0,15,0,0" Visibility="{Binding CollectionSynced, Converter={StaticResource BoolToVisibility}}">
+                <TextBlock Text="{lex:Loc Options_HSReplay_Collection_ExportToFile}" VerticalAlignment="Center" TextWrapping="Wrap"
+                           HorizontalAlignment="Center" FontSize="14" Margin="20,4"/>
+            </Button>
             <StackPanel Margin="0,40,0,0" Visibility="{Binding CollectionSynced, Converter={StaticResource BoolToVisibility}}">
                 <CheckBox Content="{lex:Loc Options_HSReplay_Collection_UploadSetting}" HorizontalAlignment="Center"
                           IsChecked="{Binding CollectionSyncingEnabled}"/>

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/HSReplay/HSReplayCollection.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/HSReplay/HSReplayCollection.xaml.cs
@@ -1,11 +1,18 @@
 ﻿using System;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Hearthstone_Deck_Tracker.Annotations;
 using Hearthstone_Deck_Tracker.Commands;
+using Hearthstone_Deck_Tracker.Hearthstone;
 using Hearthstone_Deck_Tracker.HsReplay;
 using Hearthstone_Deck_Tracker.Utility;
+using Hearthstone_Deck_Tracker.Utility.Extensions;
+using Hearthstone_Deck_Tracker.Utility.Logging;
+using Hearthstone_Deck_Tracker.Windows;
+using Newtonsoft.Json;
 
 namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.HSReplay
 {
@@ -75,6 +82,46 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.HSReplay
 
 		public object HSReplayDecksCommand => new Command(()
 			=> HSReplayNetHelper.OpenDecksUrlWithCollection("collection_syncing_banner"));
+
+		private bool _isExporting;
+
+		public object ExportCollectionCommand => new Command(() => ExportCollection().Forget());
+
+		private async Task ExportCollection()
+		{
+			if(_isExporting)
+				return;
+			_isExporting = true;
+			try
+			{
+				var collection = await CollectionHelpers.Hearthstone.GetCollection();
+				if(collection == null)
+				{
+					await Core.MainWindow.ShowMessage(
+						LocUtil.Get("Options_HSReplay_Collection_Export_Error_Title"),
+						LocUtil.Get("Options_HSReplay_Collection_Export_Error_NoCollection"));
+					return;
+				}
+
+				var fileName = Helper.ShowSaveFileDialog(
+					Helper.RemoveInvalidFileNameChars($"HDT_Collection_{collection.BattleTag}"), "json");
+				if(fileName == null)
+					return;
+
+				var json = JsonConvert.SerializeObject(collection, Formatting.Indented);
+				File.WriteAllText(fileName, json);
+			}
+			catch(Exception ex)
+			{
+				Log.Error(ex);
+				await Core.MainWindow.ShowMessage(
+					LocUtil.Get("Options_HSReplay_Collection_Export_Error_Title"), ex.Message);
+			}
+			finally
+			{
+				_isExporting = false;
+			}
+		}
 
 		public bool CollectionSyncingEnabled
 		{


### PR DESCRIPTION
## Summary

Fixes #4667.

Adds an **Export collection to file** button to the HSReplay collection options page. It serializes the currently synced collection to JSON (same format as the HSReplay collection API) through a save-file dialog. The button is shown once the collection has been synced.

When no collection is available (Hearthstone not running / never synced) a message informs the user instead.

## Screen

<img width="591" height="682" alt="image" src="https://github.com/user-attachments/assets/fa46e3fa-34aa-4d80-8bc8-74d65f2af2f5" />

## Validation

- Exported a real collection from the built app and verified the JSON (cards as `dbfId -> [counts]`, `dust`, `favorite_heroes`, `player_records`, …).
- Added unit tests for the serialization contract (top-level keys, account identifiers excluded, premium-type count layout, size).

Build validation:

- `Hearthstone Deck Tracker.csproj` / `HDTTests.csproj`
- `Debug`
- `x86` / `x64`