### PR TITLE
Harden Battlegrounds Duos session recap

### DIFF
--- a/HDTTests/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionTests.cs
+++ b/HDTTests/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hearthstone_Deck_Tracker.Controls.Overlay.Battlegrounds.Session;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Hearthstone_Deck_Tracker.Utility.Battlegrounds.BattlegroundsLastGames;
+
+namespace HDTTests.Controls.Overlay.Battlegrounds.Session
+{
+	[TestClass]
+	public class BattlegroundsSessionTests
+	{
+		// Unspecified so ToString("o")/Parse round-trip without a UTC offset
+		private static readonly DateTime Base = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Unspecified);
+
+		private static GameItem Game(double startHoursFromBase, int rating, int ratingAfter, double durationMinutes = 20)
+		{
+			var start = Base.AddHours(startHoursFromBase);
+			return new GameItem
+			{
+				StartTime = start.ToString("o"),
+				EndTime = start.AddMinutes(durationMinutes).ToString("o"),
+				Rating = rating,
+				RatingAfter = ratingAfter,
+			};
+		}
+
+		[TestMethod]
+		public void GetSessionGames_KeepsAllGames_WithinSingleSession()
+		{
+			var games = new List<GameItem> { Game(0, 6000, 6050), Game(0.5, 6050, 6100) };
+			var now = Base.AddHours(0.9);
+
+			var session = BattlegroundsSessionViewModel.GetSessionGames(games, 6100, now);
+
+			Assert.AreEqual(2, session.Count);
+		}
+
+		[TestMethod]
+		public void GetSessionGames_SplitsSession_OnGapOverTwoHours()
+		{
+			var games = new List<GameItem> { Game(0, 6000, 6050), Game(3, 6050, 6100) };
+			var now = Base.AddHours(3.5);
+
+			var session = BattlegroundsSessionViewModel.GetSessionGames(games, 6100, now);
+
+			Assert.AreEqual(1, session.Count);
+			Assert.AreEqual(games[1].StartTime, session[0].StartTime);
+		}
+
+		[TestMethod]
+		public void GetSessionGames_DoesNotWipe_WhenCurrentDuosRatingMatchesLastGame()
+		{
+			// the reset check must use the duos rating, not the (low/zero) solo rating
+			var games = new List<GameItem> { Game(0, 6000, 6050), Game(0.5, 6050, 6100) };
+			var now = Base.AddHours(0.9);
+
+			var session = BattlegroundsSessionViewModel.GetSessionGames(games, 6100, now);
+
+			Assert.AreEqual(2, session.Count);
+		}
+
+		[TestMethod]
+		public void GetSessionGames_WipesSession_OnGenuineMmrReset()
+		{
+			var games = new List<GameItem> { Game(0, 6000, 6100) };
+			var now = Base.AddHours(0.5);
+
+			var session = BattlegroundsSessionViewModel.GetSessionGames(games, 100, now);
+
+			Assert.AreEqual(0, session.Count);
+		}
+
+		[TestMethod]
+		public void GetSessionGames_WipesStaleSession_WhenLastGameOlderThanTwoHours()
+		{
+			var games = new List<GameItem> { Game(0, 6000, 6050) };
+			var now = Base.AddHours(3);
+
+			var session = BattlegroundsSessionViewModel.GetSessionGames(games, 6050, now);
+
+			Assert.AreEqual(0, session.Count);
+		}
+	}
+}

--- a/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionViewModel.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Overlay/Battlegrounds/Session/BattlegroundsSessionViewModel.xaml.cs
@@ -61,7 +61,9 @@ public class BattlegroundsSessionViewModel : ViewModel
 
 		UpdateMinionTypes();
 
-		var firstGame = await UpdateLatestGames();
+		var (loaded, firstGame) = await UpdateLatestGames();
+		if(!loaded) // keep the current recap if the account can't be resolved
+			return;
 
 		var rating = (IsDuos  ? Core.Game.BattlegroundsRatingInfo?.DuosRating : Core.Game.BattlegroundsRatingInfo?.Rating) ?? 0;
 		var ratingStart = firstGame?.Rating ?? rating;
@@ -332,14 +334,19 @@ public class BattlegroundsSessionViewModel : ViewModel
 		CompStatsWaitingMsgVisibility = Visibility.Hidden;
 	}
 
-	private async Task<GameItem?> UpdateLatestGames()
+	private async Task<(bool Loaded, GameItem? FirstGame)> UpdateLatestGames()
 	{
-		var sortedGames = (await Instance.PlayerGames(IsDuos))
+		var playerGames = await Instance.PlayerGames(IsDuos);
+		if(playerGames == null)
+			return (false, null);
+
+		var sortedGames = playerGames
 			.OrderBy(g => g.StartTime)
 			.ToList();
 		DeleteOldGames(sortedGames);
 
-		var sessionGames = GetSessionGames(sortedGames);
+		var currentRating = IsDuos ? Core.Game.BattlegroundsRatingInfo?.DuosRating : Core.Game.BattlegroundsRatingInfo?.Rating;
+		var sessionGames = GetSessionGames(sortedGames, currentRating, DateTime.Now);
 		var firstGame = sessionGames.FirstOrDefault();
 
 		SessionGames.Clear();
@@ -359,10 +366,10 @@ public class BattlegroundsSessionViewModel : ViewModel
 
 		Core.Windows.BattlegroundsSessionWindow.UpdateBattlegroundsSessionLayoutHeight();
 
-		return firstGame;
+		return (true, firstGame);
 	}
 
-	private List<GameItem> GetSessionGames(List<GameItem> sortedGames)
+	internal static List<GameItem> GetSessionGames(List<GameItem> sortedGames, int? currentRating, DateTime now)
 	{
 		DateTime? sessionStartTime = null;
 		DateTime? previousGameEndTime = null;
@@ -396,14 +403,13 @@ public class BattlegroundsSessionViewModel : ViewModel
 
 			// Check for MMR reset on last game
 			var ratingResetAfterLastGame = false;
-			if(Core.Game.BattlegroundsRatingInfo?.Rating != null)
+			if(currentRating != null)
 			{
-				var currentMMR = Core.Game.BattlegroundsRatingInfo?.Rating;
 				var sessionLastMMR = lastGame.RatingAfter;
-				ratingResetAfterLastGame = currentMMR < 500 && currentMMR - sessionLastMMR < -500;
+				ratingResetAfterLastGame = currentRating < 500 && currentRating - sessionLastMMR < -500;
 			}
 
-			var ts = DateTime.Now - DateTime.Parse(lastGame.EndTime);
+			var ts = now - DateTime.Parse(lastGame.EndTime);
 
 			if(ts.TotalHours >= 2 || ratingResetAfterLastGame)
 				return new List<GameItem>();

--- a/Hearthstone Deck Tracker/Utility/Battlegrounds/BattlegroundsLastGames.cs
+++ b/Hearthstone Deck Tracker/Utility/Battlegrounds/BattlegroundsLastGames.cs
@@ -44,11 +44,12 @@ namespace Hearthstone_Deck_Tracker.Utility.Battlegrounds
 			return accountId != null ? $"{accountId.Hi}_{accountId.Lo}" : null;
 		}
 
-		public async Task<List<GameItem>> PlayerGames(bool duos)
+		// null (not empty) when the account can't be resolved, so callers can tell that apart from "no games"
+		public async Task<List<GameItem>?> PlayerGames(bool duos)
 		{
 			var playerId = await GetPlayerId();
 			if (playerId == null)
-				return new List<GameItem>();
+				return null;
 
 			return Games.Where(g => (g.Player == null || g.Player == playerId) && (g.Duos == duos || (g.Duos == null && !duos))).ToList();
 		}


### PR DESCRIPTION
## Summary

May address #4753.

Two issues in the Battlegrounds session recap, one provable and one defensive:

1. **Solo rating used in Duos (provable).** The end-of-session MMR reset check in `GetSessionGames` compared `BattlegroundsRatingInfo.Rating` (solo) even in Duos. A duos player whose solo rating is low (e.g. unranked/0 this season) could satisfy the "MMR reset" condition and have the whole session recap wiped. It now uses the mode-appropriate rating (`DuosRating` in Duos), matching the current-rating read a few lines above.

2. **Recap wiped on transient account lookup failure (hardening).** The live recap reads the game list via `GetAccountId`, which can transiently return null / throw. That returned an empty list and cleared the recap. `PlayerGames` now returns `null` (rather than an empty list) when the account can't be resolved, and the view model keeps the current recap for that cycle instead of clearing it. The post-game `BgsLastGames.xml` save is unaffected (its rating comes from a separate, null-safe source).

The session computation was extracted into a pure, testable method to enable the tests below.

## Validation

- Could **not** reproduce the reporter's `RuntimeBinderException` locally on 1.53.14 (their report was on 1.53.9.7362), so item 2 is defensive hardening rather than a confirmed fix. Item 1 is a concrete defect independent of that exception.
- Added unit tests (TDD) for the extracted session logic: single-session retention, split on >2h gap, the duos-rating reset check, genuine MMR reset, and stale-session wipe.
- Full test suite green (219 tests).

Build validation:

- `Hearthstone Deck Tracker.csproj` / `HDTTests.csproj`
- `Debug`
- `x86` / `x64`