### PR TITLE
Add pre-commit whitespace hook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.cs eol=lf
 *.xaml eol=lf
+.githooks/pre-commit eol=lf

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Pre-commit whitespace/style checks aligned with .editorconfig.
+# - Auto-fixes trailing whitespace on staged files and re-stages them,
+#   except markdown (line-break semantics) and partially-staged files.
+# - Blocks (does not auto-fix) CRLF and wrong indentation on staged lines.
+# Only staged content is inspected, so existing code is left untouched.
+# Bypass with: git commit --no-verify
+
+IFS='
+'
+fail=0
+fixed=
+
+is_partially_staged() {
+	git diff --name-only -- "$1" | grep -qxF -- "$1"
+}
+
+for f in $(git diff --cached --name-only --diff-filter=ACM); do
+	# Skip binary files (numstat reports "-" for added/deleted counts).
+	case "$(git diff --cached --numstat -- "$f" | cut -f1)" in
+		-) continue ;;
+	esac
+
+	# Auto-fix trailing whitespace (whole file), except markdown and partial stages.
+	case "$f" in
+		*.md) ;;
+		*)
+			if ! is_partially_staged "$f"; then
+				tmp="$f.pre-commit.$$"
+				sed 's/[[:blank:]]*$//' "$f" > "$tmp"
+				if ! cmp -s "$f" "$tmp"; then
+					cat "$tmp" > "$f"
+					git add -- "$f"
+					fixed="$fixed $f"
+				fi
+				rm -f "$tmp"
+			fi
+			;;
+	esac
+
+	# .editorconfig: xml/xaml indent with spaces, everything else with tabs.
+	case "$f" in
+		*.xml|*.xaml) indent=space ;;
+		*) indent=tab ;;
+	esac
+
+	# Detect (block) remaining issues on staged added lines.
+	msg=$(git diff --cached --unified=0 -- "$f" | awk -v file="$f" -v indent="$indent" '
+		BEGIN { CR = sprintf("%c", 13); TAB = sprintf("%c", 9) }
+		/^\+\+\+/ { next }
+		/^@@/ {
+			match($0, /\+[0-9]+/)
+			ln = substr($0, RSTART + 1, RLENGTH - 1) + 0
+			next
+		}
+		substr($0, 1, 1) == "+" {
+			s = substr($0, 2)
+			lc = substr(s, length(s), 1)
+			fc = substr(s, 1, 1)
+			if (lc == CR)
+				printf "%s:%d: carriage return (use LF)\n", file, ln
+			else if (lc == " " || lc == TAB)
+				printf "%s:%d: trailing whitespace\n", file, ln
+			if (indent == "tab" && fc == " ")
+				printf "%s:%d: space indentation (use tabs)\n", file, ln
+			else if (indent == "space" && fc == TAB)
+				printf "%s:%d: tab indentation (use spaces)\n", file, ln
+			ln++
+			next
+		}
+	')
+
+	if [ -n "$msg" ]; then
+		printf '%s\n' "$msg"
+		fail=1
+	fi
+done
+
+if [ -n "$fixed" ]; then
+	echo "pre-commit: auto-fixed trailing whitespace (re-staged):$fixed"
+fi
+
+if [ "$fail" -ne 0 ]; then
+	echo
+	echo "pre-commit: fix the issues above (see .editorconfig), or bypass with: git commit --no-verify"
+	exit 1
+fi
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,8 @@ We would like to avoid wasting your time, so for non-trivial changes or fixes pl
 Also see: [How to name things in programming](http://www.slideshare.net/pirhilton/how-to-name-things-the-hardest-problem-in-programming)
 6. Know when to make exceptions.
 
+A pre-commit hook in `.githooks/` checks these whitespace rules on staged changes (auto-fixing trailing whitespace, flagging wrong indentation). `bootstrap.ps1` enables it; otherwise run `git config core.hooksPath .githooks` once.
+
 ## Commits and Pull Requests 
 
 Keep the commit log as healthy as the code. It is one of the first places new contributors will look at the project.

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -24,5 +24,8 @@ catch {
 	"Git was not found and is required to run bootstrap.bat. Download git from https://git-scm.com/download and during installation choose `"Use Git from the Windows Command Prompt`"."
 }
 
+# Enable the shared git hooks (see .githooks).
+git config core.hooksPath .githooks
+
 Invoke-Expression "msbuild Bootstrap/Bootstrap.csproj /p:Configuration=Debug"
 Invoke-Expression "msbuild 'Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj' /p:Configuration=Debug"


### PR DESCRIPTION
## Summary

Adds a shared git pre-commit hook (`.githooks/pre-commit`) that enforces the existing `.editorconfig` whitespace conventions on **staged changes only**, so existing code is never touched:

- **Auto-fixes** trailing whitespace on staged files and re-stages them, except markdown (line-break semantics) and partially-staged files (to avoid clobbering `git add -p`).
- **Blocks** (does not auto-fix) CRLF and wrong indentation (spaces in code, tabs in xml/xaml) on staged lines. Bypass with `git commit --no-verify`.

Wiring:
- `bootstrap.ps1` sets `core.hooksPath .githooks` (run on setup already).
- `CONTRIBUTING.md` documents the manual opt-in (`git config core.hooksPath .githooks`).
- `.gitattributes` pins the hook to LF so it works when checked out on Unix.

The hook is POSIX `sh` + `awk`/`sed`, works on Unix and Windows Git Bash, and adds nothing to the build.

## Validation

- Synthetic cases: trailing-ws auto-fix + re-stage; space-indentation and tab-in-xaml blocked; markdown trailing-ws preserved; partially-staged files left untouched.
- Real-file check: touching a tracked file cleaned its pre-existing trailing whitespace on the staged content and blocked an introduced space-indented line, then reverted cleanly.

Note: because trailing-ws fixing is whole-file, the first commit that touches a file with pre-existing trailing whitespace will also clean that file (invisible, harmless).