### PR TITLE
[Investigation, likely insufficient] Opponent deck/cards off-screen on mixed-DPI monitors

### DIFF
--- a/Hearthstone Deck Tracker/Utility/User32.cs
+++ b/Hearthstone Deck Tracker/Utility/User32.cs
@@ -97,6 +97,10 @@ namespace Hearthstone_Deck_Tracker
 		[DllImport("user32.dll")]
 		public static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, uint nFlags);
 
+		// Only available on Windows 10 1607+; callers must handle EntryPointNotFoundException.
+		[DllImport("user32.dll")]
+		private static extern uint GetDpiForWindow(IntPtr hWnd);
+
 		[DllImport("user32.dll")]
 		public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
@@ -272,13 +276,41 @@ namespace Hearthstone_Deck_Tracker
 
 			if(dpiScaling)
 			{
-				ptUL.X = (int)(ptUL.X / Helper.DpiScalingX);
-				ptUL.Y = (int)(ptUL.Y / Helper.DpiScalingY);
-				ptLR.X = (int)(ptLR.X / Helper.DpiScalingX);
-				ptLR.Y = (int)(ptLR.Y / Helper.DpiScalingY);
+				var (scaleX, scaleY) = GetDpiScalingForWindow(hsHandle);
+				ptUL.X = (int)(ptUL.X / scaleX);
+				ptUL.Y = (int)(ptUL.Y / scaleY);
+				ptLR.X = (int)(ptLR.X / scaleX);
+				ptLR.Y = (int)(ptLR.Y / scaleY);
 			}
 
 			return new Rectangle(ptUL.X, ptUL.Y, ptLR.X - ptUL.X, ptLR.Y - ptUL.Y);
+		}
+
+		// Helper.DpiScalingX/Y reflect the DPI of whichever HDT window last raised its
+		// Loaded event, which is not necessarily the monitor Hearthstone is on. On a
+		// multi-monitor setup with mixed scaling this produced the wrong client rect for
+		// the game window (HDT#3445 - opponent's cards/deck rendered off-screen).
+		// GetDpiForWindow (Windows 10 1607+) returns the DPI of the monitor the given
+		// window actually is on, so we prefer that and only fall back to the older,
+		// window-agnostic value on OS versions where the API doesn't exist.
+		private static (double X, double Y) GetDpiScalingForWindow(IntPtr hWnd)
+		{
+			try
+			{
+				var dpi = GetDpiForWindow(hWnd);
+				if(dpi > 0)
+				{
+					var scale = dpi / 96.0;
+					return (scale, scale);
+				}
+			}
+			catch(EntryPointNotFoundException)
+			{
+			}
+			catch(DllNotFoundException)
+			{
+			}
+			return (Helper.DpiScalingX, Helper.DpiScalingY);
 		}
 
 		public static void BringHsToForeground()


### PR DESCRIPTION
## Status
Opening as **draft**: this addresses one concrete, verified root cause (see below), but I have not been able to runtime-test it (no Windows/multi-monitor mixed-DPI rig available to me), and there's a real chance it only fixes part of the underlying problem - see "Known limitation" below. Marking as draft rather than claiming this is a complete fix.

## Summary
- `GetHearthstoneRect()` converts Hearthstone's client rect from screen pixels to WPF units using the global `Helper.DpiScalingX`/`DpiScalingY` fields.
- Those fields are set exactly once each, in `MainWindow`'s and `OverlayWindow`'s `Loaded` handlers, from whichever window's monitor happened to be current *at load time* - not from the monitor Hearthstone is actually on, and never refreshed afterwards (no `WM_DPICHANGED`/`DpiChanged` handling anywhere in the codebase). This part I verified directly by reading the code - it's unambiguously stale/wrong-window state.
- On a multi-monitor setup with mixed scaling (e.g. HDT's windows first load on a 100% monitor, Hearthstone runs fullscreen on a 150% monitor), this produces a wrong client rect. `OverlayWindow.UpdatePosition()` applies that rect directly to the whole overlay's `Top/Left/Width/Height`, so the overlay - including the opponent's card/deck panel - ends up shifted, sometimes off the visible game area.
- This matches the long-standing community report in #3445 ("Deck list is offscreen on 2nd display"), where the only known workaround was setting all monitors to the same scaling, or forcing "system DPI" override in the exe's compatibility settings.

## Fix
- Use `GetDpiForWindow` (Windows 10 1607+) to read the DPI of the monitor Hearthstone's own window is currently on, at the point we compute its rect, instead of relying on stale global state captured from an unrelated window.
- Falls back to the previous `Helper.DpiScalingX/Y` behavior if the API isn't available (e.g. older Windows versions HDT still supports), so there's no regression on unsupported OS versions.
- Scoped narrowly to `User32.GetHearthstoneRect`; no change to the app's overall DPI-awareness mode, to keep the change low-risk.

## Known limitation
In the #3445 thread, `@strican` found evidence that in Hearthstone's **fullscreen** mode specifically, `GetClientRect`/`ClientToScreen` may return coordinates as if DPI virtualization weren't happening at all (possibly a Unity/DirectX fullscreen quirk), independent of which monitor's DPI you divide by. If that's still the case, this PR fixes the "wrong/stale monitor" half of the bug but may not fully fix the fullscreen case by itself. I don't have a way to verify which of these is actually happening on current Windows/Hearthstone versions - flagging this so reviewers/testers know what to check for.

## Request for verification
I'd appreciate it if someone who can reproduce #3445, or a maintainer, could test this on a real mixed-DPI multi-monitor setup (both windowed and fullscreen Hearthstone) before this is considered for merge. Happy to adjust the approach (e.g. `MonitorFromWindow`/`GetDpiForMonitor`) if needed.

I'm also aware `CONTRIBUTING.md` asks for prior approval on non-trivial changes and a signed CLA before merge - opening this as a draft/concrete starting point for discussion rather than a merge-ready PR; happy to go through those steps as needed.

## Test plan
- [ ] Reproduce #3445 on a real mixed-DPI multi-monitor Windows setup with Hearthstone fullscreen on the differently-scaled monitor.
- [ ] Confirm the opponent (and player) overlay panels now render within the visible game area with this change.
- [ ] Repeat in windowed mode.
- [ ] Confirm no regression on a single-monitor / uniform-DPI setup.
