### PR TITLE
Recover StatsWindow position when it ends up off-screen

### DIFF
--- a/Hearthstone Deck Tracker/Windows/StatsWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/StatsWindow.xaml.cs
@@ -1,7 +1,10 @@
 ﻿#region
 
 using System.ComponentModel;
+using System.Linq;
 using System.Windows;
+using System.Windows.Forms;
+using Point = System.Drawing.Point;
 
 #endregion
 
@@ -24,6 +27,19 @@ namespace Hearthstone_Deck_Tracker.Windows
 				Left = Config.Instance.StatsWindowLeft.Value;
 			if(Config.Instance.StatsWindowTop.HasValue)
 				Top = Config.Instance.StatsWindowTop.Value;
+
+			var titleBarCorners = new[]
+			{
+				new Point((int)Left + 5, (int)Top + 5),
+				new Point((int)(Left + Width) - 5, (int)Top + 5),
+				new Point((int)Left + 5, (int)(Top + TitlebarHeight) - 5),
+				new Point((int)(Left + Width) - 5, (int)(Top + TitlebarHeight) - 5)
+			};
+			if(!Screen.AllScreens.Any(s => titleBarCorners.Any(c => s.WorkingArea.Contains(c))))
+			{
+				Top = 100;
+				Left = 100;
+			}
 		}
 
 		public Thickness TitleBarMargin => new Thickness(0, TitlebarHeight, 0, 0);


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA (see https://github.com/HearthSim/cla/pull/76)

## Summary
- `PlayerWindow`, `OpponentWindow`, `MainWindow` and `TimerWindow` all restore their saved `Left`/`Top` from config, then check the window's title bar corners against `Screen.AllScreens` and reset to `(100, 100)` if none of them land on a currently connected screen.
- `StatsWindow` restores its saved position the same way, but never got this check. If the monitor it was last on gets disconnected/disabled/reconfigured (or the saved coordinates otherwise stop matching any current screen), it can end up completely off-screen with no way back short of editing/deleting the config file.
- This is #3427, and matches a case a maintainer (@riQQ) mentioned in that thread happening to the stats window specifically (reported via Discord, with a screenshot).

## Fix
Adds the same title-bar-corner-vs-`Screen.AllScreens` check already used (and presumably already battle-tested) in the other four windows - copied verbatim, no new logic. Scoped to `StatsWindow.xaml.cs` only.

## Why I'm fairly confident in this one
Unlike my previous PR on the DPI/mixed-monitor overlay issue (which I ended up closing after finding my fix for it didn't actually work), this isn't a new mechanism - it's applying an existing, already-shipped pattern from 4 sibling windows to a 5th window that's simply missing it. I don't have a Windows box to click through the exact repro (disconnect a monitor HDT was last positioned on, relaunch), but the logic itself isn't new or unverified, it's copy-pasted from code that's already running in production for the other windows.

## Test plan
- [ ] Move the stats window (open as a separate window, not the flyout) onto a secondary monitor, close HDT, disable/disconnect that monitor, relaunch HDT, open the stats window again - it should now appear at (100, 100) instead of staying off-screen.
- [ ] Confirm normal open/close/position-save behavior is unaffected on a single-monitor setup.

