### PR TITLE
Fix update status bar getting stuck empty after periodic update check

### DIFF
--- a/Hearthstone Deck Tracker/Utility/Updating/Updater.Squirrel.cs
+++ b/Hearthstone Deck Tracker/Utility/Updating/Updater.Squirrel.cs
@@ -25,6 +25,11 @@ namespace Hearthstone_Deck_Tracker.Utility.Updating
 
 		public static async void CheckForUpdates(bool force = false)
 		{
+			// An update has already been downloaded and installed, and is just waiting for a
+			// restart. Checking again would reset the status bar (UpdaterState.Checking/None
+			// both hide the "click to update" message) while leaving it visible but empty.
+			if(Status.UpdaterState == UpdaterState.Available)
+				return;
 			if(!force && !ShouldCheckForUpdates())
 				return;
 			_lastUpdateCheck = DateTime.Now;


### PR DESCRIPTION
Fixes #4775

### Problem

Once an update is downloaded and installed, HDT shows a status bar with "A new update is available - Click here to update now". But the periodic background update check (`UpdateOverlayAsync` -> `Updater.CheckForUpdates()`) keeps running while HDT is open. On its next tick, `SquirrelUpdate()` resets `UpdaterState` to `Checking`, then `None` (since the update was already applied and no new release is found). Both of these states collapse the status bar's inner content, but nothing collapses the status bar itself back to `Collapsed`, leaving an empty, contentless blue bar visible with no indication that a restart is needed to apply the pending update.

### Fix

`CheckForUpdates` now returns immediately if `UpdaterState` is already `Available`, since there's no need to check for updates again while one is already downloaded and waiting for a restart. This keeps the actionable "click here to update now" message visible until the user restarts.
