### PR TITLE
Fix: don't feed non-Timewarp special shops into the tavern markers overlay

### DIFF
--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -1739,13 +1739,13 @@ namespace Hearthstone_Deck_Tracker.Windows
 			if(args.IsActive && boardCards.Count > 0 && userHasTier7 && hasTimewarpMechanic)
 			{
 				ShowBattlegroundsTimewarpPanel(boardCards);
+
+				Core.Overlay.BattlegroundsMinionPinningViewModel.OnShopChange(boardCards, args.MousedOverSlot);
 			}
 			else
 			{
 				HideBattlegroundsTimewarpPanel();
 			}
-
-			Core.Overlay.BattlegroundsMinionPinningViewModel.OnShopChange(boardCards, args.MousedOverSlot);
 		}
 
 		private void BgsInspirationCover_OnMouseDown(object sender, MouseButtonEventArgs e) => HideBgsInspiration();


### PR DESCRIPTION
Fixes #4777

### Problem

`OverlayWindow.HandleSpecialShop` handles updates from `SpecialShopChoicesStateWatcher`, which fires whenever the game shows the "special shop" UI. That UI isn't exclusive to the seasonal Timewarp mechanic — heroes like Morchie and Murozond trigger the same special shop for their own rewind-style hero power, regardless of whether the current Battlegrounds meta period actually has the `timewarp` mechanic active.

Previously, the method correctly gated the `TimewarpNotificationPanel` toast behind `hasTimewarpMechanic`, but the following line ran unconditionally:

```csharp
Core.Overlay.BattlegroundsMinionPinningViewModel.OnShopChange(boardCards, args.MousedOverSlot);
```

`OnShopChange` populates every slot of the tavern markers overlay (`BgsMinionPinning`), which is a full-canvas grid rendered on top of other overlay panels (Composition Guide, minion browser, game history, etc.). It uses per-card `Hovered` state and slot position to decide whether to show pin icons and the recommended-comps popout for each card.

When Morchie/Murozond triggered the special shop outside of an actual Timewarp period, this method still ran with that shop's board cards, but the shop UI on screen was the hero-specific rewind screen, not the regular tavern layout the overlay assumes. The result: stale/mismatched hover and slot data left an empty recommended-comps popout box rendered at the wrong location, overlapping other overlay panels with a blank rectangle (see screenshots in the issue).

### Fix

Move the `OnShopChange` call inside the same `hasTimewarpMechanic` (and `userHasTier7`/`args.IsActive`/`boardCards.Count > 0`) gate that already protects the toast panel, so the tavern markers overlay is only fed special-shop data when it's genuinely the supported Timewarp shop. Outside of that, the regular `OnPlayZoneChange` path (driven by the normal Bob's Tavern board) remains the sole source of truth for the tavern markers overlay, exactly as it was before Timewarp existed.

This is a single-purpose, minimal change: no new gating conditions were introduced, the existing condition is just applied consistently to both effects of a special shop event.

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA
